### PR TITLE
Publish version once on startup

### DIFF
--- a/MqttTopics.h
+++ b/MqttTopics.h
@@ -40,7 +40,7 @@
 
 #define mqtt_topic_info_hardware_version "/info/hardwareVersion"
 #define mqtt_topic_info_firmware_version "/info/firmwareVersion"
-
+#define mqtt_topic_info_nuki_hub_version "/info/nukiHubVersion"
 
 #define mqtt_topic_keypad "/keypad"
 #define mqtt_topic_keypad_command_action "/keypad/command/action"

--- a/Network.cpp
+++ b/Network.cpp
@@ -11,6 +11,7 @@
 
 Network* Network::_inst = nullptr;
 unsigned long Network::_ignoreSubscriptionsTs = 0;
+bool _versionPublished = false;
 
 RTC_NOINIT_ATTR char WiFi_fallbackDetect[14];
 
@@ -288,6 +289,10 @@ bool Network::update()
             publishUInt(_maintenancePathPrefix, mqtt_topic_freeheap, esp_get_free_heap_size());
             publishString(_maintenancePathPrefix, mqtt_topic_restart_reason_fw, getRestartReason().c_str());
             publishString(_maintenancePathPrefix, mqtt_topic_restart_reason_esp, getEspRestartReason().c_str());
+        }
+        if (!_versionPublished) {
+            publishString(mqtt_topic_info_nuki_hub_version, NUKI_HUB_VERSION);
+            _versionPublished = true;
         }
         _lastMaintenanceTs = ts;
     }
@@ -709,6 +714,23 @@ void Network::publishHASSConfig(char* deviceType, const char* baseTopic, char* n
                          name,
                          baseTopic,
                          mqtt_topic_info_hardware_version,
+                         deviceType,
+                         "",
+                         "",
+                         "diagnostic",
+                         "",
+                         { { "enabled_by_default", "true" },
+                           {"ic", "mdi:counter"}});
+
+        // NUKI Hub version
+        publishHassTopic("sensor",
+                         "nuki_hub_version",
+                         uidString,
+                         "_nuki_hub__version",
+                         "NUKI Hub version",
+                         name,
+                         baseTopic,
+                         mqtt_topic_info_nuki_hub_version,
                          deviceType,
                          "",
                          "",


### PR DESCRIPTION
Add nuki hub version to mqtt. I would like to use this in home assistant (alongside with Github integration for latest releases) to notify when there is a new release.


Note: I don't have the toolchain set up yet, so didn't compile this.

