### PR TITLE
Fix sound level sensor category

### DIFF
--- a/Network.cpp
+++ b/Network.cpp
@@ -1045,7 +1045,7 @@ void Network::publishHASSConfigSoundLevel(char *deviceType, const char *baseTopi
                      deviceType,
                      "",
                      "",
-                     "config",
+                     "diagnostic",
                      mqtt_topic_config_sound_level,
                      { { "ic", "mdi:volume-source" },
                        { "min", "0" },


### PR DESCRIPTION
Sensors are read-only entities and thus `config` is an invalid category for them (new check in Home Assistant 2023.11.0)