### PR TITLE
fix misspelled mqttDisonnect to mqttDisconnect

### DIFF
--- a/Network.cpp
+++ b/Network.cpp
@@ -496,7 +496,7 @@ bool Network::reconnect()
             _device->printError();
             _mqttConnectionState = 0;
             _nextReconnect = millis() + 5000;
-            _device->mqttDisonnect(true);
+            _device->mqttDisconnect(true);
         }
     }
     return _mqttConnectionState > 0;

--- a/NukiWrapper.cpp
+++ b/NukiWrapper.cpp
@@ -725,7 +725,7 @@ bool NukiWrapper::hasDoorSensor() const
 {
     return _keyTurnerState.doorSensorState == Nuki::DoorSensorState::DoorClosed ||
            _keyTurnerState.doorSensorState == Nuki::DoorSensorState::DoorOpened ||
-           _keyTurnerState.doorSensorState == Nuki::DoorSensorState::Calibrating;;
+           _keyTurnerState.doorSensorState == Nuki::DoorSensorState::Calibrating;
 }
 
 void NukiWrapper::disableHASS()

--- a/networkDevices/EthLan8720Device.cpp
+++ b/networkDevices/EthLan8720Device.cpp
@@ -243,7 +243,7 @@ bool EthLan8720Device::mqttConnect()
     }
 }
 
-bool EthLan8720Device::mqttDisonnect(bool force)
+bool EthLan8720Device::mqttDisconnect(bool force)
 {
     if(_useEncryption)
     {

--- a/networkDevices/EthLan8720Device.h
+++ b/networkDevices/EthLan8720Device.h
@@ -51,7 +51,7 @@ public:
 
     bool mqttConnect() override;
 
-    bool mqttDisonnect(bool force) override;
+    bool mqttDisconnect(bool force) override;
 
     void setWill(const char *topic, uint8_t qos, bool retain, const char *payload) override;
 

--- a/networkDevices/NetworkDevice.h
+++ b/networkDevices/NetworkDevice.h
@@ -39,7 +39,7 @@ public:
     virtual bool mqttConnected() const = 0;
     virtual void mqttSetServer(const char* host, uint16_t port) = 0;
     virtual bool mqttConnect() = 0;
-    virtual bool mqttDisonnect(bool force) = 0;
+    virtual bool mqttDisconnect(bool force) = 0;
     virtual void setWill(const char* topic, uint8_t qos, bool retain, const char* payload) = 0;
     virtual void mqttSetCredentials(const char* username, const char* password) = 0;
     virtual void mqttOnMessage(espMqttClientTypes::OnMessageCallback callback) = 0;

--- a/networkDevices/W5500Device.cpp
+++ b/networkDevices/W5500Device.cpp
@@ -259,7 +259,7 @@ bool W5500Device::mqttConnect()
     return _mqttClient.connect();
 }
 
-bool W5500Device::mqttDisonnect(bool force)
+bool W5500Device::mqttDisconnect(bool force)
 {
     return _mqttClient.disconnect(force);
 }

--- a/networkDevices/W5500Device.h
+++ b/networkDevices/W5500Device.h
@@ -47,7 +47,7 @@ public:
 
     bool mqttConnect() override;
 
-    bool mqttDisonnect(bool force) override;
+    bool mqttDisconnect(bool force) override;
 
     void setWill(const char *topic, uint8_t qos, bool retain, const char *payload) override;
 

--- a/networkDevices/WifiDevice.cpp
+++ b/networkDevices/WifiDevice.cpp
@@ -261,7 +261,7 @@ bool WifiDevice::mqttConnect()
     }
 }
 
-bool WifiDevice::mqttDisonnect(bool force)
+bool WifiDevice::mqttDisconnect(bool force)
 {
     if(_useEncryption)
     {

--- a/networkDevices/WifiDevice.h
+++ b/networkDevices/WifiDevice.h
@@ -41,7 +41,7 @@ public:
 
     bool mqttConnect() override;
 
-    bool mqttDisonnect(bool force) override;
+    bool mqttDisconnect(bool force) override;
 
     void setWill(const char *topic, uint8_t qos, bool retain, const char *payload) override;
 


### PR DESCRIPTION
Hi,
I've just fixed a typo in mqttDisconnect method name, the "c" was missing and fixed a double semicolon.