### PR TITLE
Add Accesslevel "Lock and Unlock operation only"

### DIFF
--- a/AccessLevel.h
+++ b/AccessLevel.h
@@ -4,5 +4,6 @@ enum class AccessLevel
 {
     Full = 0,
     LockOnly = 1,
-    ReadOnly = 2
+    ReadOnly = 2,
+    LockAndUnlock = 3
 };

--- a/NukiOpenerWrapper.cpp
+++ b/NukiOpenerWrapper.cpp
@@ -486,6 +486,14 @@ LockActionResult NukiOpenerWrapper::onLockActionReceivedCallback(const char *val
             nukiOpenerInst->_nextLockAction = action;
             return LockActionResult::Success;
             break;
+        case AccessLevel::LockAndUnlock:
+            if(action == NukiOpener::LockAction::ActivateRTO || action == NukiOpener::LockAction::ActivateCM || action == NukiOpener::LockAction::DeactivateRTO || action == NukiOpener::LockAction::DeactivateCM)
+            {
+                nukiOpenerInst->_nextLockAction = action;
+                return LockActionResult::Success;
+            }
+            return LockActionResult::AccessDenied;
+            break;
         case AccessLevel::LockOnly:
             if(action == NukiOpener::LockAction::DeactivateRTO || action == NukiOpener::LockAction::DeactivateCM)
             {

--- a/NukiWrapper.cpp
+++ b/NukiWrapper.cpp
@@ -455,6 +455,14 @@ LockActionResult NukiWrapper::onLockActionReceivedCallback(const char *value)
             nukiInst->_nextLockAction = action;
             return LockActionResult::Success;
             break;
+        case AccessLevel::LockAndUnlock:
+            if(action == NukiLock::LockAction::Lock || action == NukiLock::LockAction::Unlock || action == NukiLock::LockAction::LockNgo || action == NukiLock::LockAction::FullLock)
+            {
+                nukiInst->_nextLockAction = action;
+                return LockActionResult::Success;
+            }
+            return LockActionResult::AccessDenied;
+            break;
         case AccessLevel::LockOnly:
             if(action == NukiLock::LockAction::Lock)
             {

--- a/WebCfgServer.cpp
+++ b/WebCfgServer.cpp
@@ -1308,6 +1308,7 @@ const std::vector<std::pair<String, String>> WebCfgServer::getAccessLevelOptions
     std::vector<std::pair<String, String>> options;
 
     options.push_back(std::make_pair(std::to_string((int)AccessLevel::Full).c_str(), "Full"));
+    options.push_back(std::make_pair(std::to_string((int)AccessLevel::LockAndUnlock).c_str(), "Lock and unlock operation only"));
     options.push_back(std::make_pair(std::to_string((int)AccessLevel::LockOnly).c_str(), "Lock operation only"));
     options.push_back(std::make_pair(std::to_string((int)AccessLevel::ReadOnly).c_str(), "Read only"));
 


### PR DESCRIPTION
Adds an accesslevel where locking and unlocking (and Lock N' Go) is possible through MQTT but not unlatching or reconfiguration of the Nuki lock and Keypad.

Usage is European style door/lock with a knob on the outside where I don't want to be able to open the door through MQTT (reasons as described in #177) but do want my smart home application to lock/unlock the deadbolt based on geo-fencing (when I enter the general area of the lock my smart home application will remove the deadbolt so my keypad/fob/app/key than only needs to take care of the latch)