### PR TITLE
Add configuration url in Home Assistant discovery

### DIFF
--- a/Network.cpp
+++ b/Network.cpp
@@ -719,6 +719,18 @@ void Network::publishHASSConfig(char* deviceType, const char* baseTopic, char* n
         json["dev"]["mf"] = "Nuki";
         json["dev"]["mdl"] = deviceType;
         json["dev"]["name"] = name;
+        
+        String cuUrl = _preferences->getString(preference_mqtt_hass_cu_url);
+
+        if (cuUrl != "")
+        {
+            json["dev"]["cu"] = cuUrl;
+        }
+        else
+        {
+            json["dev"]["cu"] = "http://" + _device->localIP();
+        }
+        
         json["~"] = baseTopic;
         json["name"] = nullptr;
         json["unique_id"] = String(uidString) + "_lock";

--- a/PreferencesKeys.h
+++ b/PreferencesKeys.h
@@ -20,6 +20,7 @@
 #define preference_mqtt_crt "mqttcrt"
 #define preference_mqtt_key "mqttkey"
 #define preference_mqtt_hass_discovery "hassdiscovery"
+#define preference_mqtt_hass_cu_url "hassConfigUrl"
 #define preference_ip_dhcp_enabled "dhcpena"
 #define preference_ip_address "ipaddr"
 #define preference_ip_subnet "ipsub"
@@ -64,7 +65,7 @@ private:
             preference_mqtt_user, preference_mqtt_password, preference_mqtt_log_enabled, preference_lock_enabled,
             preference_mqtt_lock_path, preference_opener_enabled, preference_mqtt_opener_path,
             preference_lock_max_keypad_code_count, preference_opener_max_keypad_code_count, preference_mqtt_ca,
-            preference_mqtt_crt, preference_mqtt_key, preference_mqtt_hass_discovery,
+            preference_mqtt_crt, preference_mqtt_key, preference_mqtt_hass_discovery, preference_mqtt_hass_cu_url,
             preference_ip_dhcp_enabled, preference_ip_address, preference_ip_subnet, preference_ip_gateway, preference_ip_dns_server,
             preference_network_hardware, preference_network_wifi_fallback_disabled, preference_rssi_publish_interval,
             preference_hostname, preference_network_timeout, preference_restart_on_disconnect,

--- a/WebCfgServer.cpp
+++ b/WebCfgServer.cpp
@@ -352,6 +352,11 @@ bool WebCfgServer::processArgs(String& message)
                 configChanged = true;
             }
         }
+        else if(key == "HASSCUURL")
+        {
+            _preferences->putString(preference_mqtt_hass_cu_url, value);
+            configChanged = true;
+        }        
         else if(key == "HOSTNAME")
         {
             _preferences->putString(preference_hostname, value);
@@ -764,6 +769,7 @@ void WebCfgServer::buildMqttConfigHtml(String &response)
     response.concat("<h3>Advanced MQTT and Network Configuration</h3>");
     response.concat("<table>");
     printInputField(response, "HASSDISCOVERY", "Home Assistant discovery topic (empty to disable; usually homeassistant)", _preferences->getString(preference_mqtt_hass_discovery).c_str(), 30);
+    printInputField(response, "HASSCUURL", "Home Assistant device configuration URL (empty to use http://LOCALIP; fill when using a reverse proxy for example)", _preferences->getString(preference_mqtt_hass_cu_url).c_str(), 261);
     printTextarea(response, "MQTTCA", "MQTT SSL CA Certificate (*, optional)", _preferences->getString(preference_mqtt_ca).c_str(), TLS_CA_MAX_SIZE, _network->encryptionSupported(), true);
     printTextarea(response, "MQTTCRT", "MQTT SSL Client Certificate (*, optional)", _preferences->getString(preference_mqtt_crt).c_str(), TLS_CERT_MAX_SIZE, _network->encryptionSupported(), true);
     printTextarea(response, "MQTTKEY", "MQTT SSL Client Key (*, optional)", _preferences->getString(preference_mqtt_key).c_str(), TLS_KEY_MAX_SIZE, _network->encryptionSupported(), true);

--- a/networkDevices/EthLan8720Device.cpp
+++ b/networkDevices/EthLan8720Device.cpp
@@ -159,6 +159,11 @@ int8_t EthLan8720Device::signalStrength()
     return -1;
 }
 
+String EthLan8720Device::localIP()
+{
+    return Ethernet.localIP().toString();
+}
+
 void EthLan8720Device::mqttSetClientId(const char *clientId)
 {
     if(_useEncryption)

--- a/networkDevices/EthLan8720Device.cpp
+++ b/networkDevices/EthLan8720Device.cpp
@@ -161,7 +161,7 @@ int8_t EthLan8720Device::signalStrength()
 
 String EthLan8720Device::localIP()
 {
-    return Ethernet.localIP().toString();
+    return ETH.localIP().toString();
 }
 
 void EthLan8720Device::mqttSetClientId(const char *clientId)

--- a/networkDevices/EthLan8720Device.h
+++ b/networkDevices/EthLan8720Device.h
@@ -36,6 +36,8 @@ public:
     virtual bool isConnected();
 
     int8_t signalStrength() override;
+    
+    String localIP() override;
 
     void mqttSetClientId(const char *clientId) override;
 

--- a/networkDevices/NetworkDevice.h
+++ b/networkDevices/NetworkDevice.h
@@ -32,7 +32,7 @@ public:
     virtual bool isConnected() = 0;
     virtual int8_t signalStrength() = 0;
     
-    virtual String localIP() = '';
+    virtual String localIP() = 0;
 
     virtual void mqttSetClientId(const char* clientId) = 0;
     virtual void mqttSetCleanSession(bool cleanSession) = 0;

--- a/networkDevices/NetworkDevice.h
+++ b/networkDevices/NetworkDevice.h
@@ -31,6 +31,8 @@ public:
 
     virtual bool isConnected() = 0;
     virtual int8_t signalStrength() = 0;
+    
+    virtual String localIP() = '';
 
     virtual void mqttSetClientId(const char* clientId) = 0;
     virtual void mqttSetCleanSession(bool cleanSession) = 0;

--- a/networkDevices/W5500Device.cpp
+++ b/networkDevices/W5500Device.cpp
@@ -229,6 +229,11 @@ int8_t W5500Device::signalStrength()
     return 127;
 }
 
+String W5500Device::localIP()
+{
+    return Ethernet.localIP().toString();
+}
+
 void W5500Device::mqttSetClientId(const char *clientId)
 {
     _mqttClient.setClientId(clientId);

--- a/networkDevices/W5500Device.h
+++ b/networkDevices/W5500Device.h
@@ -32,6 +32,8 @@ public:
     virtual bool isConnected();
 
     int8_t signalStrength() override;
+    
+    String localIP() override;
 
     void mqttSetClientId(const char *clientId) override;
 

--- a/networkDevices/WifiDevice.cpp
+++ b/networkDevices/WifiDevice.cpp
@@ -180,6 +180,11 @@ int8_t WifiDevice::signalStrength()
     return WiFi.RSSI();
 }
 
+String WifiDevice::localIP()
+{
+    return WiFi.localIP().toString();
+}
+
 void WifiDevice::clearRtcInitVar(WiFiManager *)
 {
     memset(WiFiDevice_reconfdetect, 0, sizeof WiFiDevice_reconfdetect);

--- a/networkDevices/WifiDevice.h
+++ b/networkDevices/WifiDevice.h
@@ -26,6 +26,8 @@ public:
     virtual bool isConnected();
 
     int8_t signalStrength() override;
+    
+    String localIP() override;
 
     void mqttSetClientId(const char *clientId) override;
 


### PR DESCRIPTION
-Adds a configuration URL to Home Assistant discovery. 

By default will point to http://HUBIP. 

Can be set in "Advanced MQTT and Network Configuration" to anything (e.g. "https://nukihub.customdomain.com" for those using reverse proxies).

Closes #277 