### PR TITLE
Allow migrating configuration on updates that change configuration scheme

### DIFF
--- a/PreferencesKeys.h
+++ b/PreferencesKeys.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #define preference_started_before "run"
+#define preference_config_version "confVersion"
 #define preference_device_id_lock "deviceId"
 #define preference_device_id_opener "deviceIdOp"
 #define preference_mqtt_broker "mqttbroker"
@@ -61,8 +62,8 @@ class DebugPreferences
 private:
     std::vector<char*> _keys =
     {
-            preference_started_before, preference_device_id_lock, preference_device_id_opener, preference_mqtt_broker, preference_mqtt_broker_port,
-            preference_mqtt_user, preference_mqtt_password, preference_mqtt_log_enabled, preference_lock_enabled,
+            preference_started_before, preference_config_version, preference_device_id_lock, preference_device_id_opener, preference_mqtt_broker, 
+            preference_mqtt_broker_port, preference_mqtt_user, preference_mqtt_password, preference_mqtt_log_enabled, preference_lock_enabled,
             preference_mqtt_lock_path, preference_opener_enabled, preference_mqtt_opener_path,
             preference_lock_max_keypad_code_count, preference_opener_max_keypad_code_count, preference_mqtt_ca,
             preference_mqtt_crt, preference_mqtt_key, preference_mqtt_hass_discovery, preference_mqtt_hass_cu_url,

--- a/main.cpp
+++ b/main.cpp
@@ -147,6 +147,21 @@ bool initPreferences()
         preferences->putBool(preference_started_before, true);
         preferences->putBool(preference_lock_enabled, true);
     }
+    else
+    {
+        int configVer = preferences->getInt(preference_config_version);
+
+        if(configVer < (atof(NUKI_HUB_VERSION) * 100))
+        {
+            //Example
+            //if (configVer < 833)
+            //{
+                //MIGRATE SETTINGS
+            //}
+
+            preferences->putInt(preference_config_version, atof(NUKI_HUB_VERSION) * 100);
+        }
+    }
 
     return firstStart;
 }


### PR DESCRIPTION
This PR puts in place a system for migrating config variables on first boot with a new version if that version changes the configuration scheme.

I'm working on more granular access control which will mean splitting the currently set access level to multiple new settings for users that are upgrading.