### PR TITLE
Disable UpdateAuthData when no PIN is set

### DIFF
--- a/NukiOpenerWrapper.cpp
+++ b/NukiOpenerWrapper.cpp
@@ -404,6 +404,8 @@ void NukiOpenerWrapper::updateConfig()
 
 void NukiOpenerWrapper::updateAuthData()
 {
+    if(_nukiOpener.getSecurityPincode() == 0) return;    
+    
     Nuki::CmdResult result = _nukiOpener.retrieveLogEntries(0, 0, 0, true);
     if(result != Nuki::CmdResult::Success)
     {

--- a/NukiWrapper.cpp
+++ b/NukiWrapper.cpp
@@ -374,6 +374,8 @@ void NukiWrapper::updateConfig()
 
 void NukiWrapper::updateAuthData()
 {
+    if(_nukiLock.getSecurityPincode() == 0) return;
+    
     Nuki::CmdResult result = _nukiLock.retrieveLogEntries(0, 0, 0, true);
     if(result != Nuki::CmdResult::Success)
     {


### PR DESCRIPTION
As per the API (and as evident from using the Nuki App) the Nuki PIN is required to retrieve auth data from the lock.

There currently is no check in NukiWrapper::updateAuthData() or NukiOpenerWrapper::updateAuthData() to check if the security PIN is set.

Enabling Publish Auth Data without a PIN set will result in lockouts of not just Nuki Hub but all systems using the API because Nuki Hub tries to retrieve the auth data with a PIN of 0.

PR fixes this behaviour.