### PR TITLE
Prevent Home Assistant warnings on Ring Event

### DIFF
--- a/MqttTopics.h
+++ b/MqttTopics.h
@@ -19,6 +19,7 @@
 #define mqtt_topic_query_lockstate_command_result "/lock/query/lockstateCommandResult"
 #define mqtt_topic_lock_binary_state "/lock/binaryState"
 #define mqtt_topic_lock_continuous_mode "/lock/continuousMode"
+#define mqtt_topic_lock_ring "/lock/ring"
 #define mqtt_topic_lock_trigger "/lock/trigger"
 #define mqtt_topic_lock_last_lock_action "/lock/lastLockAction"
 #define mqtt_topic_lock_log "/lock/log"

--- a/Network.cpp
+++ b/Network.cpp
@@ -1227,7 +1227,7 @@ void Network::publishHASSConfigRingDetect(char *deviceType, const char *baseTopi
                           {"pl_off", "locked"}});
 
         DynamicJsonDocument json(_bufferSize);
-        json = createHassJson(uidString, "_ring_event", "Ring", name, baseTopic, String("~") + mqtt_topic_lock_state, deviceType, "doorbell", "", "", "", {{"value_template", "{ \"event_type\": \"{{ value }}\" }"}});
+        json = createHassJson(uidString, "_ring_event", "Ring", name, baseTopic, String("~") + mqtt_topic_lock_ring, deviceType, "doorbell", "", "", "", {{"value_template", "{ \"event_type\": \"{{ value }}\" }, \"duration\": 2"}});
         json["event_types"][0] = "ring";
         serializeJson(json, _buffer, _bufferSize);
         String path = createHassTopicPath("event", "ring", uidString);

--- a/NetworkOpener.cpp
+++ b/NetworkOpener.cpp
@@ -277,6 +277,7 @@ void NetworkOpener::publishKeyTurnerState(const NukiOpener::OpenerState& keyTurn
 void NetworkOpener::publishRing()
 {
     publishString(mqtt_topic_lock_state, "ring");
+    publishString(mqtt_topic_lock_ring, "ring");
     _resetLockStateTs = millis() + 2000;
 }
 


### PR DESCRIPTION
New ring event introduced in #299 creates warnings in the Home Assistant log. 
PR should fix this behaviour.