### PR TITLE
Update Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -20,8 +20,8 @@ COPY lib /usr/src/nuki_hub/lib
 COPY networkDevices /usr/src/nuki_hub/networkDevices
 COPY CMakeLists.txt /usr/src/nuki_hub
 COPY index.html /usr/src/nuki_hub
-COPY *.h /usr/src/nuki_hub
-COPY *.cpp /usr/src/nuki_hub
+COPY *.h /usr/src/nuki_hub/
+COPY *.cpp /usr/src/nuki_hub/
 
 RUN mkdir -p /usr/src/nuki_hub/build
 


### PR DESCRIPTION
When trying to build using Docker (24.0.5 in the dev VM) the `build_with_docker.sh` command fails with:

```
Step 13/22 : COPY *.h /usr/src/nuki_hub
When using COPY with more than one source file, the destination must be a directory and end with a /

```

This PR fixes this error.