### PR TITLE
Fix webcfg ota link

### DIFF
--- a/Network.cpp
+++ b/Network.cpp
@@ -381,7 +381,7 @@ bool Network::update()
                     
                     if (_latestVersion != _preferences->getString(preference_latest_version).c_str()) 
                     {
-                        _preferences->setString(_latestVersion); 
+                        _preferences->putString(preference_latest_version, _latestVersion); 
                     }
                 }
             }

--- a/Network.cpp
+++ b/Network.cpp
@@ -369,13 +369,20 @@ bool Network::update()
 
             int httpResponseCode = https.GET();
 
-            if (httpResponseCode == HTTP_CODE_OK || httpResponseCode == HTTP_CODE_MOVED_PERMANENTLY) {
+            if (httpResponseCode == HTTP_CODE_OK || httpResponseCode == HTTP_CODE_MOVED_PERMANENTLY) 
+            {
                 DynamicJsonDocument doc(6144);
                 DeserializationError jsonError = deserializeJson(doc, https.getStream());
 
-                if (!jsonError) {
+                if (!jsonError) 
+                {
                     _latestVersion = doc["tag_name"];
                     publishString(_maintenancePathPrefix, mqtt_topic_info_nuki_hub_latest, _latestVersion);
+                    
+                    if (_latestVersion != _preferences->getString(preference_latest_version).c_str()) 
+                    {
+                        _preferences->setString(_latestVersion); 
+                    }
                 }
             }
 
@@ -667,11 +674,6 @@ void Network::disableAutoRestarts()
 int Network::mqttConnectionState()
 {
     return _mqttConnectionState;
-}
-
-const char* Network::latestHubVersion()
-{
-    return _latestVersion;
 }
 
 bool Network::encryptionSupported()

--- a/Network.h
+++ b/Network.h
@@ -65,7 +65,6 @@ public:
     void publishPresenceDetection(char* csv);
 
     int mqttConnectionState(); // 0 = not connected; 1 = connected; 2 = connected and mqtt processed
-    const char* latestHubVersion();
     bool encryptionSupported();
     const String networkDeviceName() const;
 

--- a/PreferencesKeys.h
+++ b/PreferencesKeys.h
@@ -58,6 +58,7 @@
 #define preference_has_mac_byte_0 "macb0"
 #define preference_has_mac_byte_1 "macb1"
 #define preference_has_mac_byte_2 "macb2"
+#define preference_latest_version "latest"
 
 class DebugPreferences
 {
@@ -78,7 +79,7 @@ private:
             preference_register_as_app, preference_command_nr_of_retries,
             preference_command_retry_delay, preference_cred_user, preference_cred_password, preference_publish_authdata,
             preference_publish_debug_info, preference_presence_detection_timeout,
-            preference_has_mac_saved, preference_has_mac_byte_0, preference_has_mac_byte_1, preference_has_mac_byte_2,
+            preference_has_mac_saved, preference_has_mac_byte_0, preference_has_mac_byte_1, preference_has_mac_byte_2, preference_latest_version,
     };
     std::vector<char*> _redact =
     {

--- a/WebCfgServer.cpp
+++ b/WebCfgServer.cpp
@@ -636,12 +636,10 @@ void WebCfgServer::buildHtml(String& response)
     }
     printParameter(response, "Firmware", version.c_str(), "/info");
 
-    const char* _latestVersion = _network->latestHubVersion();
-
     if(_preferences->getBool(preference_check_updates))
     {
         //if(atof(_latestVersion) > atof(NUKI_HUB_VERSION) || (atof(_latestVersion) == atof(NUKI_HUB_VERSION) && _latestVersion != NUKI_HUB_VERSION)) {
-        printParameter(response, "Latest Firmware", _latestVersion, "/ota");
+        printParameter(response, "Latest Firmware", _preferences->getString(preference_latest_version).c_str(), "/ota");
         //}
     }
 


### PR DESCRIPTION
The current implementation that shows the latest version on the WebCfg page sometimes produces empty or garbled text.

Example:

![image](https://github.com/technyon/nuki_hub/assets/25727444/256307b5-5b63-45f7-adf9-2f00293e0342)

I'm not sure of the root cause, but saving the saving the latest version to the cfg when latest version changes makes sure that the latest version is always known and seems to fix this issue.