### PR TITLE
Fix Home Assistant Unlatch button for opener

### DIFF
--- a/Network.cpp
+++ b/Network.cpp
@@ -1061,7 +1061,7 @@ void Network::publishHASSConfig(char* deviceType, const char* baseTopic, char* n
                          "unlatch",
                          uidString,
                          "_unlatch_button",
-                         "Unlatch",
+                         "Open",
                          name,
                          baseTopic,
                          "",
@@ -1071,7 +1071,7 @@ void Network::publishHASSConfig(char* deviceType, const char* baseTopic, char* n
                          "",
                          String("~") + mqtt_topic_lock_action,
                          { { "enabled_by_default", "false" },
-                           { "pl_prs", "unlatch" }});
+                           { "pl_prs", openAction }});
 
     }
 }


### PR DESCRIPTION
The Unlatch button added in #284 only works for the Lock and not for the Opener because the command that is sent to nuki(opener)/lock/action is harcoded to unlatch instead of unlatch for the lock and electronicStrikeActuation for the opener.

Thix PR fixes this and changes the name of the button to "Open" instead of "Unlatch" as previously discussed.

Closes #310 