### PR TITLE
Multiple fixes (Nuki ID + README + ACL + DoorSensor/Keypad)

### DIFF
--- a/PreferencesKeys.h
+++ b/PreferencesKeys.h
@@ -6,6 +6,8 @@
 #define preference_config_version "confVersion"
 #define preference_device_id_lock "deviceId"
 #define preference_device_id_opener "deviceIdOp"
+#define preference_nuki_id_lock "nukiId"
+#define preference_nuki_id_opener "nukidOp"
 #define preference_mqtt_broker "mqttbroker"
 #define preference_mqtt_broker_port "mqttport"
 #define preference_mqtt_user "mqttuser"
@@ -68,9 +70,8 @@ class DebugPreferences
 private:
     std::vector<char*> _keys =
     {
-            preference_started_before, preference_config_version, preference_device_id_lock, preference_device_id_opener, preference_mqtt_broker,
-            preference_mqtt_broker_port, preference_mqtt_user, preference_mqtt_password, preference_mqtt_log_enabled, preference_check_updates, preference_lock_enabled,
-            preference_mqtt_lock_path, preference_opener_enabled, preference_opener_continuous_mode, preference_mqtt_opener_path,
+            preference_started_before, preference_config_version, preference_device_id_lock, preference_device_id_opener, preference_nuki_id_lock, preference_nuki_id_opener,  preference_mqtt_broker, preference_mqtt_broker_port, preference_mqtt_user, preference_mqtt_password, preference_mqtt_log_enabled, preference_check_updates,
+            preference_lock_enabled, preference_mqtt_lock_path, preference_opener_enabled, preference_opener_continuous_mode, preference_mqtt_opener_path,
             preference_lock_max_keypad_code_count, preference_opener_max_keypad_code_count, preference_mqtt_ca,
             preference_mqtt_crt, preference_mqtt_key, preference_mqtt_hass_discovery, preference_mqtt_hass_cu_url,
             preference_ip_dhcp_enabled, preference_ip_address, preference_ip_subnet, preference_ip_gateway, preference_ip_dns_server,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Feel free to join us on Discord: https://discord.gg/feB9FnMY
 ## Supported devices
 
 <b>Supported ESP32 devices:</b>
-- Any dual-core ESP32, except the ESP32-S3 (because of compilation issues)
+- All dual-core ESP32 models with WIFI and BLE which are supported by Arduino Core 2.0.14 should work, but builds are currently only provided for the ESP32 and not for the ESP32-S3 or ESP32-C3.
+- The ESP32-S2 has no BLE and as such can't run Nuki Hub.
+- The ESP32-C6 and ESP32-H2 are not supported by Arduino Core 2.0.14 as such can't run Nuki Hub (at this time).
 
 <b>Supported Nuki devices:</b>
 - Nuki Smart Lock 1.0

--- a/main.cpp
+++ b/main.cpp
@@ -146,6 +146,10 @@ bool initPreferences()
     {
         preferences->putBool(preference_started_before, true);
         preferences->putBool(preference_lock_enabled, true);
+        preferences->putBool(preference_admin_enabled, true);
+
+        uint32_t aclPrefs[17] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        preferences->putBytes(preference_acl, (byte*)(&aclPrefs), sizeof(aclPrefs));
     }
     else
     {


### PR DESCRIPTION
- [x] Fix for incorrect Nuki ID creating lots of Home Assistant auto discovery devices/entities
- [x] README update to better reflect ESP32 device support
- [x] Fix for granular ACL support to set admin and full ACL level on first boot
- [x] Remove duplicate `else if` in `NukiWrapper::onConfigUpdateReceived`
- [ ] Show granular ACL correctly on info page in WebCfg
- [ ] Allow forcing DoorSensor/Keypad availability to prevent entity removal from Home Assistant discovery
