### PR TITLE
Make the code optional when updating keypad using JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ To change Nuki Lock/Opener keypad settings set the `keypad/actionJson` topic to 
 |------------------|----------|----------|----------|------------------------------------------------------------------------------------------------------------------|----------------------------------------|
 | action           | Required | Required | Required | The action to execute                                                                                            | "delete", "add", "update"              |
 | codeId           | Required | Not used | Required | The code ID of the existing code to delete or update                                                             | Integer                                |
-| code             | Not used | Required | Required | The code to create or update                                                                       | 6-digit Integer without zero's, can't start with "12"|
+| code             | Not used | Required | Optional | The code to create or update                                                                       | 6-digit Integer without zero's, can't start with "12"|
 | enabled          | Not used | Not used | Optional | Enable or disable the code, always enabled on add, disabled if not set on update                                 | 1 = enabled, 0 = disabled              |
 | name             | Not used | Required | Required | The name of the code to create or update                                                                         | String, max 20 chars                   |
 | timeLimited      | Not used | Optional | Optional | If this authorization is restricted to access only at certain times, disabled if not set (requires enabled = 1)  | 1 = enabled, 0 = disabled              |
@@ -459,7 +459,7 @@ To change Nuki Lock/Opener keypad settings set the `keypad/actionJson` topic to 
 Examples:
 - Delete: `{ "action": "delete", "codeId": "1234" }`
 - Add: `{ "action": "add", "code": "589472", "name": "Test", "timeLimited": "1", "allowedFrom": "2024-04-12 10:00:00", "allowedUntil": "2034-04-12 10:00:00", "allowedWeekdays": [ "wed", "thu", "fri" ], "allowedFromTime": "08:00", "allowedUntilTime": "16:00" }`
-- Update: `{ "action": "update", "codeId": "1234", "code": "589472", "enabled": "1", "name": "Test", "timeLimited": "1", "allowedFrom": "2024-04-12 10:00:00", "allowedUntil": "2034-04-12 10:00:00", "allowedWeekdays": [ "mon", "tue", "sat", "sun" ], "allowedFromTime": "08:00", "allowedUntilTime": "16:00" }`
+- Update: `{ "action": "update", "codeId": "1234", "enabled": "1", "name": "Test", "timeLimited": "1", "allowedFrom": "2024-04-12 10:00:00", "allowedUntil": "2034-04-12 10:00:00", "allowedWeekdays": [ "mon", "tue", "sat", "sun" ], "allowedFromTime": "08:00", "allowedUntilTime": "16:00" }`
 
 ### Result of attempted keypad code changes
 

--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -525,9 +525,12 @@ void NukiOpenerWrapper::updateKeypad()
 
         _keypadCodeIds.clear();
         _keypadCodeIds.reserve(entries.size());
+        _keypadCodes.clear();
+        _keypadCodes.reserve(entries.size());
         for(const auto& entry : entries)
         {
             _keypadCodeIds.push_back(entry.codeId);
+            _keypadCodes.push_back(entry.code);
         }
     }
 
@@ -1504,7 +1507,7 @@ void NukiOpenerWrapper::onKeypadJsonCommandReceived(const char *value)
                     return;
                 }
             }
-            else
+            else if (strcmp(action, "update") != 0)
             {
                 _network->publishKeypadJsonCommandResult("noCodeSet");
                 return;
@@ -1685,7 +1688,14 @@ void NukiOpenerWrapper::onKeypadJsonCommandReceived(const char *value)
                 entry.codeId = codeId;
                 size_t nameLen = strlen(name);
                 memcpy(&entry.name, name, nameLen > 20 ? 20 : nameLen);
-                entry.code = code;
+
+                if(code) entry.code = code;
+                else
+                {
+                    auto it = std::find(_keypadCodeIds.begin(), _keypadCodeIds.end(), codeId);
+                    entry.code = _keypadCodes[(it - _keypadCodeIds.begin())];
+                }
+                
                 entry.enabled = enabled == 0 ? 0 : 1;
                 entry.timeLimited = timeLimited == 1 ? 1 : 0;
 

--- a/src/NukiOpenerWrapper.h
+++ b/src/NukiOpenerWrapper.h
@@ -105,6 +105,7 @@ private:
     int _retryLockstateCount = 0;
     unsigned long _nextRetryTs = 0;
     std::vector<uint16_t> _keypadCodeIds;
+    std::vector<uint32_t> _keypadCodes;
     std::vector<uint8_t> _timeControlIds;
 
     NukiOpener::OpenerState _lastKeyTurnerState;

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -506,9 +506,12 @@ void NukiWrapper::updateKeypad()
 
         _keypadCodeIds.clear();
         _keypadCodeIds.reserve(entries.size());
+        _keypadCodes.clear();
+        _keypadCodes.reserve(entries.size());
         for(const auto& entry : entries)
         {
             _keypadCodeIds.push_back(entry.codeId);
+            _keypadCodes.push_back(entry.code);
         }
     }
 
@@ -1490,7 +1493,7 @@ void NukiWrapper::onKeypadJsonCommandReceived(const char *value)
                     return;
                 }
             }
-            else
+            else if (strcmp(action, "update") != 0)
             {
                 _network->publishKeypadJsonCommandResult("noCodeSet");
                 return;
@@ -1671,7 +1674,14 @@ void NukiWrapper::onKeypadJsonCommandReceived(const char *value)
                 entry.codeId = codeId;
                 size_t nameLen = strlen(name);
                 memcpy(&entry.name, name, nameLen > 20 ? 20 : nameLen);
-                entry.code = code;
+                
+                if(code) entry.code = code;
+                else
+                {
+                    auto it = std::find(_keypadCodeIds.begin(), _keypadCodeIds.end(), codeId);
+                    entry.code = _keypadCodes[(it - _keypadCodeIds.begin())];
+                }
+
                 entry.enabled = enabled == 0 ? 0 : 1;
                 entry.timeLimited = timeLimited == 1 ? 1 : 0;
 

--- a/src/NukiWrapper.h
+++ b/src/NukiWrapper.h
@@ -94,6 +94,7 @@ private:
     bool _publishAuthData = false;
     bool _clearAuthData = false;
     std::vector<uint16_t> _keypadCodeIds;
+    std::vector<uint32_t> _keypadCodes;
     std::vector<uint8_t> _timeControlIds;
 
     NukiLock::KeyTurnerState _lastKeyTurnerState;


### PR DESCRIPTION
Allows updating keypad codes (enable/disable, enable/disable time limited, change allowed times/weekdays) without knowing and/or sending the keypad code itself.