### PR TITLE
webcfg: cache static files

### DIFF
--- a/src/WebCfgServer.cpp
+++ b/src/WebCfgServer.cpp
@@ -2028,9 +2028,6 @@ void WebCfgServer::buildHtmlHeader(String &response)
 {
     response.concat("<html><head>");
     response.concat("<meta name='viewport' content='width=device-width, initial-scale=1'>");
-//    response.concat("<style>");
-//    response.concat(stylecss);
-//    response.concat("</style>");
     response.concat("<link rel='stylesheet' href='/style.css'>");
     response.concat("<title>Nuki Hub</title></head><body>");
 
@@ -2299,11 +2296,13 @@ void WebCfgServer::handleOtaUpload()
 void WebCfgServer::sendCss()
 {
     // escaped by https://www.cescaper.com/
+    _server.sendHeader("Cache-Control", "public, max-age=3600");
     _server.send(200, "text/css", stylecss, sizeof(stylecss));
 }
 
 void WebCfgServer::sendFavicon()
 {
+    _server.sendHeader("Cache-Control", "public, max-age=604800");
     _server.send(200, "image/png", (const char*)favicon_32x32, sizeof(favicon_32x32));
 }
 


### PR DESCRIPTION
Adding `Cache-Control` header to files, the browser will automatically skip download on each page visit.

![image](https://github.com/technyon/nuki_hub/assets/1145001/daa19020-dbe0-4b3f-b7d0-841ecc9205f8)
