### PR TITLE
config: disable MQTT publish presence

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -327,11 +327,14 @@ bool Network::update()
 
     if(_presenceCsv != nullptr && strlen(_presenceCsv) > 0)
     {
-        bool success = publishString(_mqttPresencePrefix, mqtt_topic_presence, _presenceCsv);
-        if(!success)
+        if(_preferences->getBool(preference_publish_presence))
         {
-            Log->println(F("Failed to publish presence CSV data."));
-            Log->println(_presenceCsv);
+            bool success = publishString(_mqttPresencePrefix, mqtt_topic_presence, _presenceCsv);
+            if(!success)
+            {
+                Log->println(F("Failed to publish presence CSV data."));
+                Log->println(_presenceCsv);
+            }
         }
         _presenceCsv = nullptr;
     }

--- a/src/PreferencesKeys.h
+++ b/src/PreferencesKeys.h
@@ -54,6 +54,7 @@
 #define preference_timecontrol_control_enabled (char*)"tcCntrlEnabled"
 #define preference_timecontrol_info_enabled (char*)"tcInfoEnabled"
 #define preference_publish_authdata (char*)"pubAuth"
+#define preference_publish_presence (char*)"pubPresence"
 #define preference_acl (char*)"aclLckOpn"
 #define preference_conf_lock_basic_acl (char*)"confLckBasAcl"
 #define preference_conf_lock_advanced_acl (char*)"confLckAdvAcl"
@@ -99,7 +100,7 @@ private:
             preference_keypad_info_enabled, preference_acl, preference_timecontrol_control_enabled, preference_timecontrol_info_enabled,
             preference_conf_lock_basic_acl, preference_conf_lock_advanced_acl, preference_conf_opener_basic_acl, preference_conf_opener_advanced_acl,
             preference_access_level, preference_register_as_app, preference_command_nr_of_retries, preference_command_retry_delay, preference_cred_user,
-            preference_cred_password, preference_publish_authdata, preference_publish_debug_info, preference_presence_detection_timeout,
+            preference_cred_password, preference_publish_authdata, preference_publish_presence, preference_publish_debug_info, preference_presence_detection_timeout,
             preference_has_mac_saved, preference_has_mac_byte_0, preference_has_mac_byte_1, preference_has_mac_byte_2, preference_latest_version,
             preference_task_size_network, preference_task_size_nuki, preference_task_size_pd, preference_authlog_max_entries, preference_keypad_max_entries, preference_timecontrol_max_entries
     };
@@ -115,7 +116,7 @@ private:
             preference_started_before, preference_mqtt_log_enabled, preference_check_updates, preference_lock_enabled, preference_opener_enabled, preference_opener_continuous_mode,
             preference_enable_bootloop_reset, preference_webserver_enabled, preference_find_best_rssi, preference_restart_on_disconnect, preference_keypad_control_enabled,
             preference_keypad_info_enabled, preference_timecontrol_control_enabled, preference_timecontrol_info_enabled, preference_register_as_app, preference_ip_dhcp_enabled,
-            preference_publish_authdata, preference_has_mac_saved, preference_publish_debug_info, preference_network_wifi_fallback_disabled
+            preference_publish_authdata, preference_publish_presence, preference_has_mac_saved, preference_publish_debug_info, preference_network_wifi_fallback_disabled
     };
 
     const bool isRedacted(const char* key) const

--- a/src/WebCfgServer.cpp
+++ b/src/WebCfgServer.cpp
@@ -576,6 +576,11 @@ bool WebCfgServer::processArgs(String& message)
             _preferences->putBool(preference_publish_authdata, (value == "1"));
             configChanged = true;
         }
+        else if(key == "PUBPRESENCE")
+        {
+            _preferences->putBool(preference_publish_presence, (value == "1"));
+            configChanged = true;
+        }
         else if(key == "ACLLCKLCK")
         {
             aclPrefs[0] = ((value == "1") ? 1 : 0);
@@ -1400,6 +1405,7 @@ void WebCfgServer::buildAccLvlHtml(String &response)
     printCheckBox(response, "TCPUB", "Publish time control entries information", _preferences->getBool(preference_timecontrol_info_enabled), "");
     printCheckBox(response, "TCENA", "Add, modify and delete time control entries", _preferences->getBool(preference_timecontrol_control_enabled), "");
     printCheckBox(response, "PUBAUTH", "Publish authorisation log (may reduce battery life)", _preferences->getBool(preference_publish_authdata), "");
+    printCheckBox(response, "PUBPRESENCE", "Publish Bluetooth devices near Nuki Hub", _preferences->getBool(preference_publish_presence), "");
     response.concat("</table><br>");
     if(_nuki != nullptr)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ bool initPreferences()
     {
         preferences->putBool(preference_started_before, true);
         preferences->putBool(preference_lock_enabled, true);
+        preferences->putBool(preference_publish_presence, true);
         uint32_t aclPrefs[17] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
         preferences->putBytes(preference_acl, (byte*)(&aclPrefs), sizeof(aclPrefs));
         uint32_t basicLockConfigAclPrefs[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
@@ -171,6 +172,10 @@ bool initPreferences()
 
         if(configVer < (atof(NUKI_HUB_VERSION) * 100))
         {
+            if (configVer < 835){
+                preferences->putBool(preference_publish_presence, true);
+            }
+
             if (configVer < 834)
             {
                 if(preferences->getInt(preference_keypad_control_enabled))


### PR DESCRIPTION
Currently, Nuki Hub sends Bluetooth devices nearby to **MQTT** `nuki/presence/devices` **every 3-5 seconds**.
Unsure if it is used in a special way, so I am adding a flag to allow user to disable it.