### PR TITLE
ci(build): major rework GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    name: Build ${{ matrix.board }}
+    name: Build ${{ matrix.board }} (${{ matrix.build }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -71,10 +71,10 @@ jobs:
           cp -v bin/boot_app0.bin ${BUILD}/${VARIANT}/boot_app0.bin
           cp -v how-to-flash.txt ${BUILD}/${VARIANT}/how-to-flash.txt
 
-          cat << EOF | tee release/${VARIANT}/flash.sh
-          esptool.py --chip esp32 merge_bin -o release/${VARIANT}/webflash_nuki_hub_${VARIANT}.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x1000 release/${VARIANT}/bootloader.bin 0x10000 release/${VARIANT}/nuki_hub_${VARIANT}.bin 0x8000 release/${VARIANT}/nuki_hub.partitions.bin
+          cat << EOF | tee ${BUILD}/${VARIANT}/flash.sh
+          esptool.py --chip esp32 merge_bin -o ${BUILD}/${VARIANT}/webflash_nuki_hub_${VARIANT}.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x1000 ${BUILD}/${VARIANT}/bootloader.bin 0x10000 ${BUILD}/${VARIANT}/nuki_hub_${VARIANT}.bin 0x8000 ${BUILD}/${VARIANT}/nuki_hub.partitions.bin
           EOF
-          chmod a+x release/${VARIANT}/flash.sh
+          chmod a+x ${BUILD}/${VARIANT}/flash.sh
 
       - name: Upload Artifact ${{ matrix.board }}-${{ matrix.build }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           fi
 
           # look for documentation on flash and copy the command
-          command=`sed -n '/^Howto flash (esptool)$/,$p' ${DOC} | sed -n "/^## ${BOARD}$/,\${ n; n; p; }" | head -n1`
+          command=`sed -n '/^Howto flash (esptool)$/,$p' ${DOC} | sed -n '/^## '"${BOARD}"'$/,\${ n; n; p; }' | head -n1`
 
           if [ -z "$command" ]; then
             echo "::error::Command not found in document ${DOC} for board ${BOARD}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,21 +19,20 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        board: [esp32-s3, esp32-c3, esp32solo1]
         build: [release, debug]
         include:
         - board: esp32dev
           name: esp32
-        - board: esp32-s3
-          name: esp32s3
-        - board: esp32-c3
-          name: esp32c3
-        - board: esp32solo1
-          name: esp32solo1
     env:
       BOARD: ${{ matrix.board }}
-      VARIANT: ${{ matrix.name }}
+      VARIANT: ${{ matrix.name || matrix.board }}
       BUILD: ${{ matrix.build }}
     steps:
+      - name: Fix variant name
+        run: |
+          # remove dash character
+          echo "VARIANT=${VARIANT//-/}" | tee -a ${GITHUB_ENV}
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -60,7 +59,9 @@ jobs:
           if [ "$BUILD" = "debug" ]; then
             BOARD="${BOARD}_dbg"
           fi
-          pio run --environment ${BOARD}
+          echo "::group::Building with PlatformIO"
+            pio run --environment ${BOARD}
+          echo "::endgroup::"
           mkdir -p ${BUILD}/${VARIANT}
           cp -v .pio/build/${BOARD}/firmware.bin ${BUILD}/${VARIANT}/nuki_hub_${VARIANT}.bin
           cp -v .pio/build/${BOARD}/partitions.bin ${BUILD}/${VARIANT}/nuki_hub.partitions.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,55 +136,30 @@ jobs:
     name: Release new version
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
+    #if: startsWith(github.ref, 'refs/tags')
     steps:
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}    
-      - name: Download esp32dev
+      - name: Download release assets
         uses: actions/download-artifact@v4
         with:
-          name: esp32-assets
-          path: release/esp32dev
-      - name: Download esp32-s3
+          path: release
+          pattern: *-release-assets
+      - name: Download debug assets
         uses: actions/download-artifact@v4
         with:
-          name: esp32-s3-assets
-          path: release/esp32s3
-      - name: Download esp32-c3
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32-c3-assets
-          path: release/esp32c3
-      - name: Download esp32solo1
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32solo1-assets
-          path: release/esp32solo1
-      - name: Download esp32dev-debug
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32-debug-assets
-          path: debug/esp32dev
-      - name: Download esp32-s3-debug
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32-s3-debug-assets
-          path: debug/esp32s3
-      - name: Download esp32-c3-debug
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32-c3-debug-assets
-          path: debug/esp32c3
-      - name: Download esp32solo1-debug
-        uses: actions/download-artifact@v4
-        with:
-          name: esp32solo1-debug-assets
-          path: debug/esp32solo1
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          path: debug
+          pattern: *-debug-assets
+      - name: List files
+        run: |
+          find release/
+          find debug/
+          exit 1
       - name: Build the zip archive for ESP32
         run: |
           cd release/esp32dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,14 @@ jobs:
           fi
 
           # look for documentation on flash and copy the command
-          command=`sed -n '/^Howto flash (esptool)$/,$p' ${DOC} | sed -n "/^## ${BOARD}\$/,${ n; n; p; }" | head -n1`
+          command=`sed -n '/^Howto flash (esptool)$/,$p' ${DOC} | sed -n "/^## ${BOARD}$/,\${ n; n; p; }" | head -n1`
 
-          echo "Command:"
+          if [ -z "$command" ]; then
+            echo "::error::Command not found in document ${DOC} for board ${BOARD}"
+            exit 1
+          fi
+
+          echo -n "Command: "
           echo "$command" | tee ${FILES}/flash.sh
           chmod a+x ${FILES}/flash.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         include:
         - board: esp32dev
           name: esp32
+          build: [release, debug]
     env:
       BOARD: ${{ matrix.board }}
       VARIANT: ${{ matrix.name || matrix.board }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Upload Artifact ${{ matrix.board }}-${{ matrix.build }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ format('{0}-{1}-assets', matrix.name, matrix.build) }}
-          path: ${{ matrix.build }}/${{ matrix.name }}
+          name: ${{ format('{0}-{1}-assets', env.VARIANT, matrix.build) }}
+          path: ${{ matrix.build }}/${{ env.VARIANT }}
 
       # ----
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     name: Release new version
     needs: build
     runs-on: ubuntu-latest
-    #if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Get the version
         id: get_version
@@ -165,34 +165,33 @@ jobs:
 
           for FOLDER in release/*; do
             MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
-            echo "${FOLDER} --"
+            ZIPFILE="${NUKI}-${MODEL}.zip"
+
+            echo "${FOLDER} -- ${ZIPFILE}"
             cd $FOLDER
 
-            ZIPFILE="${NUKI}-${MODEL}.zip"
+            zip -9r ../../${ZIPFILE} * -x "webflash_nuki_hub_*.bin"
             ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
 
-            zip -9r ../../${ZIPFILE} * -x "webflash_nuki_hub_*.bin"
             cd ../..
           done
 
           for FOLDER in debug/*; do
             MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
-            echo "${FOLDER} --"
-            cd $FOLDER
-
             ZIPFILE="${NUKI}-${MODEL}-DEBUG.zip"
 
+            echo "${FOLDER} -- ${ZIPFILE}"
+            cd $FOLDER
+
             zip -9r ../../${ZIPFILE} *
+            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
+
             cd ../..
           done
 
           # remove last character
           ARTIFACTS="${ARTIFACTS%?}"
           echo "artifacts=${ARTIFACTS}" | tee -a ${GITHUB_OUTPUT}
-      - name: List files
-        run: |
-          find . -name '*.zip'
-          exit 1
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,43 +155,44 @@ jobs:
         with:
           path: debug
           pattern: '*-debug-assets'
+      - name: Build zip archives
+        id: zip
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          NUKI="NukiHub-${VERSION}"
+          ARTIFACTS=""
+
+          for FOLDER in release/*; do
+            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
+            echo "${FOLDER} --"
+            cd $FOLDER
+
+            ZIPFILE="${NUKI}-${MODEL}.zip"
+            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
+
+            zip -9r ../../${ZIPFILE} * -x "webflash_nuki_hub_*.bin"
+            cd ../..
+          done
+
+          for FOLDER in debug/*; do
+            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
+            echo "${FOLDER} --"
+            cd $FOLDER
+
+            ZIPFILE="${NUKI}-${MODEL}-DEBUG.zip"
+
+            zip -9r ../../${ZIPFILE} *
+            cd ../..
+          done
+
+          # remove last character
+          ARTIFACTS="${ARTIFACTS%?}"
+          echo "artifacts=${ARTIFACTS}" | tee -a ${GITHUB_OUTPUT}
       - name: List files
         run: |
-          find release/
-          find debug/
+          find . -name '*.zip'
           exit 1
-      - name: Build the zip archive for ESP32
-        run: |
-          cd release/esp32dev
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32.zip * -x "webflash_nuki_hub_esp32.bin"
-      - name: Build the zip archive for ESP32-S3
-        run: |
-          cd release/esp32s3
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-S3.zip * -x "webflash_nuki_hub_esp32s3.bin"
-      - name: Build the zip archive for ESP32-C3
-        run: |
-          cd release/esp32c3
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-C3.zip * -x "webflash_nuki_hub_esp32c3.bin"
-      - name: Build the zip archive for ESP32-SOLO1
-        run: |
-          cd release/esp32solo1
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-SOLO1.zip * 
-      - name: Build the zip archive for ESP32 Debug
-        run: |
-          cd debug/esp32dev
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-DEBUG.zip *
-      - name: Build the zip archive for ESP32-S3 Debug
-        run: |
-          cd debug/esp32s3
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-S3-DEBUG.zip *
-      - name: Build the zip archive for ESP32-C3 Debug
-        run: |
-          cd debug/esp32c3
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-C3-DEBUG.zip *
-      - name: Build the zip archive for ESP32-SOLO1 Debug
-        run: |
-          cd debug/esp32solo1
-          zip -9r ../../NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-SOLO1-DEBUG.zip *          
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -201,17 +202,12 @@ jobs:
           updateOnlyUnreleased: true
           draft: true
           name: "Nuki Hub ${{ steps.get_version.outputs.VERSION }}"
-          artifacts: "NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-S3.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-C3.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-SOLO1.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-DEBUG.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-S3-DEBUG.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-C3-DEBUG.zip,NukiHub-${{ steps.get_version.outputs.VERSION }}-ESP32-SOLO1-DEBUG.zip"
+          artifacts: ${{ steps.zip.outputs.artifacts }}
           artifactContentType: application/zip
       - name: Copy binaries to ota and webflash
         run: |
-          cp release/esp32dev/nuki_hub_esp32.bin ota/nuki_hub_esp32.bin
-          cp release/esp32s3/nuki_hub_esp32s3.bin ota/nuki_hub_esp32s3.bin
-          cp release/esp32c3/nuki_hub_esp32c3.bin ota/nuki_hub_esp32c3.bin
-          cp release/esp32solo1/nuki_hub_esp32solo1.bin ota/nuki_hub_esp32solo1.bin
-          cp release/esp32dev/webflash_nuki_hub_esp32.bin webflash/webflash_nuki_hub_esp32.bin
-          cp release/esp32s3/webflash_nuki_hub_esp32s3.bin webflash/webflash_nuki_hub_esp32s3.bin
-          cp release/esp32c3/webflash_nuki_hub_esp32c3.bin webflash/webflash_nuki_hub_esp32c3.bin
+          cp -vf release/*/nuki_hub_*.bin ota/
+          cp -vf release/*/webflash_nuki_hub_*.bin webflash/
           rm -rf release
           rm -rf debug
           rm -rf NukiHub-*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        board: [esp32-s3, esp32-c3, esp32solo1]
+        board: [esp32dev, esp32-s3, esp32-c3, esp32solo1]
         build: [release, debug]
-        include:
-        - board: esp32dev
-          name: esp32
-          build: [release, debug]
     env:
       BOARD: ${{ matrix.board }}
       VARIANT: ${{ matrix.name || matrix.board }}
@@ -33,7 +29,13 @@ jobs:
       - name: Fix variant name
         run: |
           # remove dash character
-          echo "VARIANT=${VARIANT//-/}" | tee -a ${GITHUB_ENV}
+          export VARIANT=${VARIANT//-/}
+
+          if [ "$VARIANT" = "esp32dev" ]; then
+            VARIANT="esp32"
+          fi
+
+          echo "VARIANT=${VARIANT}" | tee -a ${GITHUB_ENV}
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,8 @@ jobs:
           # fix for docs
           if [ "$BOARD" = "ESP32SOLO1" ]; then
             BOARD="ESP32Solo1"
+          elif [ "$BOARD" = "ESP32DEV" ]; then
+            BOARD="ESP32"
           fi
 
           # look for documentation on flash and copy the command

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,10 +75,30 @@ jobs:
           cp -v bin/boot_app0.bin ${BUILD}/${VARIANT}/boot_app0.bin
           cp -v how-to-flash.txt ${BUILD}/${VARIANT}/how-to-flash.txt
 
-          cat << EOF | tee ${BUILD}/${VARIANT}/flash.sh
-          esptool.py --chip esp32 merge_bin -o ${BUILD}/${VARIANT}/webflash_nuki_hub_${VARIANT}.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x1000 ${BUILD}/${VARIANT}/bootloader.bin 0x10000 ${BUILD}/${VARIANT}/nuki_hub_${VARIANT}.bin 0x8000 ${BUILD}/${VARIANT}/nuki_hub.partitions.bin
-          EOF
-          chmod a+x ${BUILD}/${VARIANT}/flash.sh
+      - name: Pack webflash image
+        if: ${{ matrix.build == 'release' && matrix.board != 'esp32solo1' }}
+        env:
+          POSITION_BOOTLOADER: "0x0"
+          POSITION_PARTITIONS: "0x8000"
+          POSITION_BOOT_APP: "0xe000"
+          POSITION_APP: "0x10000"
+          CHIP: ${{ env.VARIANT }}
+          FILES: ${{ format('{0}/{1}', env.BUILD, env.VARIANT) }}
+        run: |
+          if [ "$BOARD" = "esp32dev" ]; then
+            POSITION_BOOTLOADER="0x1000"
+          fi
+
+          esptool.py \
+            --chip ${CHIP} \
+            merge_bin -o ${FILES}/webflash_nuki_hub_${VARIANT}.bin \
+            --flash_mode dio \
+            --flash_freq keep \
+            --flash_size keep \
+            ${POSITION_BOOT_APP} bin/boot_app0.bin \
+            ${POSITION_BOOTLOADER} ${FILES}/bootloader.bin \
+            ${POSITION_APP} ${FILES}/nuki_hub_${VARIANT}.bin \
+            ${POSITION_PARTITIONS} ${FILES}/nuki_hub.partitions.bin
 
       - name: Upload Artifact ${{ matrix.board }}-${{ matrix.build }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,15 +100,30 @@ jobs:
             ${POSITION_APP} ${FILES}/nuki_hub_${VARIANT}.bin \
             ${POSITION_PARTITIONS} ${FILES}/nuki_hub.partitions.bin
 
+      - name: Add flash script
+        env:
+          DOC: how-to-flash.txt
+          FILES: ${{ format('{0}/{1}', env.BUILD, env.VARIANT) }}
+        run: |
+          BOARD=`echo $BOARD | tr '[:lower:]' '[:upper:]'`
+
+          # fix for docs
+          if [ "$BOARD" = "ESP32SOLO1" ]; then
+            BOARD="ESP32Solo1"
+          fi
+
+          # look for documentation on flash and copy the command
+          command=`sed -n '/^Howto flash (esptool)$/,$p' ${DOC} | sed -n "/^## ${BOARD}\$/,${ n; n; p; }" | head -n1`
+
+          echo "Command:"
+          echo "$command" | tee ${FILES}/flash.sh
+          chmod a+x ${FILES}/flash.sh
+
       - name: Upload Artifact ${{ matrix.board }}-${{ matrix.build }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ format('{0}-{1}-assets', env.VARIANT, matrix.build) }}
           path: ${{ matrix.build }}/${{ env.VARIANT }}
-
-      # ----
-
-            # echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32dev/flash.sh
 
   release:
     name: Release new version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,12 +149,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: release
-          pattern: *-release-assets
+          pattern: '*-release-assets'
       - name: Download debug assets
         uses: actions/download-artifact@v4
         with:
           path: debug
-          pattern: *-debug-assets
+          pattern: '*-debug-assets'
       - name: List files
         run: |
           find release/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build ${{ matrix.board }} (${{ matrix.build }})
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         board: [esp32dev, esp32-s3, esp32-c3, esp32solo1]
         build: [release, debug]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,25 @@ permissions:
 
 jobs:
   build:
-    name: Checkout source code and build
+    name: Build ${{ matrix.board }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        build: [release, debug]
+        include:
+        - board: esp32dev
+          name: esp32
+        - board: esp32-s3
+          name: esp32s3
+        - board: esp32-c3
+          name: esp32c3
+        - board: esp32solo1
+          name: esp32solo1
+    env:
+      BOARD: ${{ matrix.board }}
+      VARIANT: ${{ matrix.name }}
+      BUILD: ${{ matrix.build }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,139 +54,38 @@ jobs:
         env:
           Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
         run: |
-          sed -i "s/unknownbuildnr/$Version (release)/g" src/Config.h
-      - name: Build PlatformIO Project esp32dev
+          sed -i "s/unknownbuildnr/$Version (${BUILD})/g" src/Config.h
+      - name: Build ${{ matrix.build }} PlatformIO Project ${{ matrix.board }}
         run: |
-          pio run --environment esp32dev
-          mkdir -p release/esp32dev
-          cp .pio/build/esp32dev/firmware.bin release/esp32dev/nuki_hub_esp32.bin
-          cp .pio/build/esp32dev/partitions.bin release/esp32dev/nuki_hub.partitions.bin
-          cp .pio/build/esp32dev/bootloader.bin release/esp32dev/bootloader.bin
-          cp bin/boot_app0.bin release/esp32dev/boot_app0.bin
-          cp how-to-flash.txt release/esp32dev/how-to-flash.txt
-          esptool.py --chip esp32 merge_bin -o release/esp32dev/webflash_nuki_hub_esp32.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x1000 release/esp32dev/bootloader.bin 0x10000 release/esp32dev/nuki_hub_esp32.bin 0x8000 release/esp32dev/nuki_hub.partitions.bin
-          echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32.bin 0x8000 nuki_hub.partitions.bin" > release/esp32dev/flash.sh
-      - name: Build PlatformIO Project esp32-s3
-        run: |
-          pio run --environment esp32-s3
-          mkdir -p release/esp32s3
-          cp .pio/build/esp32-s3/firmware.bin release/esp32s3/nuki_hub_esp32s3.bin
-          cp .pio/build/esp32-s3/partitions.bin release/esp32s3/nuki_hub.partitions.bin
-          cp .pio/build/esp32-s3/bootloader.bin release/esp32s3/bootloader.bin
-          cp bin/boot_app0.bin release/esp32s3/boot_app0.bin
-          cp how-to-flash.txt release/esp32s3/how-to-flash.txt
-          esptool.py --chip esp32s3 merge_bin -o release/esp32s3/webflash_nuki_hub_esp32s3.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x0 release/esp32s3/bootloader.bin 0x10000 release/esp32s3/nuki_hub_esp32s3.bin 0x8000 release/esp32s3/nuki_hub.partitions.bin
-          echo "esptool.py --chip esp32s3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32s3.bin 0x8000 nuki_hub.partitions.bin" > release/esp32s3/flash.sh
-      - name: Build PlatformIO Project esp32-c3
-        run: |
-          pio run --environment esp32-c3
-          mkdir -p release/esp32c3
-          cp .pio/build/esp32-c3/firmware.bin release/esp32c3/nuki_hub_esp32c3.bin
-          cp .pio/build/esp32-c3/partitions.bin release/esp32c3/nuki_hub.partitions.bin
-          cp .pio/build/esp32-c3/bootloader.bin release/esp32c3/bootloader.bin
-          cp bin/boot_app0.bin release/esp32c3/boot_app0.bin
-          cp how-to-flash.txt release/esp32c3/how-to-flash.txt
-          esptool.py --chip esp32c3 merge_bin -o release/esp32c3/webflash_nuki_hub_esp32c3.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x0 release/esp32c3/bootloader.bin 0x10000 release/esp32c3/nuki_hub_esp32c3.bin 0x8000 release/esp32c3/nuki_hub.partitions.bin
-          echo "esptool.py --chip esp32c3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32c3.bin 0x8000 nuki_hub.partitions.bin" > release/esp32c3/flash.sh
-      - name: Build PlatformIO Project esp32solo1
-        run: |
-          pio run --environment esp32solo1
-          mkdir -p release/esp32solo1
-          cp .pio/build/esp32solo1/firmware.bin release/esp32solo1/nuki_hub_esp32solo1.bin
-          cp .pio/build/esp32solo1/partitions.bin release/esp32solo1/nuki_hub.partitions.bin
-          cp .pio/build/esp32solo1/bootloader.bin release/esp32solo1/bootloader.bin
-          cp bin/boot_app0.bin release/esp32solo1/boot_app0.bin
-          cp how-to-flash.txt release/esp32solo1/how-to-flash.txt
-          echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32solo1.bin 0x8000 nuki_hub.partitions.bin" > release/esp32solo1/flash.sh
-      - name: Upload Artifact esp32dev
+          if [ "$BUILD" = "debug" ]; then
+            BOARD="${BOARD}_dbg"
+          fi
+          pio run --environment ${BOARD}
+          mkdir -p ${BUILD}/${VARIANT}
+          cp -v .pio/build/${BOARD}/firmware.bin ${BUILD}/${VARIANT}/nuki_hub_${VARIANT}.bin
+          cp -v .pio/build/${BOARD}/partitions.bin ${BUILD}/${VARIANT}/nuki_hub.partitions.bin
+          cp -v .pio/build/${BOARD}/bootloader.bin ${BUILD}/${VARIANT}/bootloader.bin
+          if [ "$BUILD" = "debug" ]; then
+            cp -v .pio/build/${BOARD}/firmware.elf ${BUILD}/${VARIANT}/nuki_hub_${VARIANT}.elf
+          fi
+          cp -v bin/boot_app0.bin ${BUILD}/${VARIANT}/boot_app0.bin
+          cp -v how-to-flash.txt ${BUILD}/${VARIANT}/how-to-flash.txt
+
+          cat << EOF | tee release/${VARIANT}/flash.sh
+          esptool.py --chip esp32 merge_bin -o release/${VARIANT}/webflash_nuki_hub_${VARIANT}.bin --flash_mode dio --flash_freq keep --flash_size keep 0xe000 bin/boot_app0.bin 0x1000 release/${VARIANT}/bootloader.bin 0x10000 release/${VARIANT}/nuki_hub_${VARIANT}.bin 0x8000 release/${VARIANT}/nuki_hub.partitions.bin
+          EOF
+          chmod a+x release/${VARIANT}/flash.sh
+
+      - name: Upload Artifact ${{ matrix.board }}-${{ matrix.build }}
         uses: actions/upload-artifact@v4
         with:
-          name: esp32-assets
-          path: release/esp32dev
-      - name: Upload Artifact esp32-s3
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32-s3-assets
-          path: release/esp32s3
-      - name: Upload Artifact esp32-c3
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32-c3-assets
-          path: release/esp32c3
-      - name: Upload Artifact esp32solo1
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32solo1-assets
-          path: release/esp32solo1
-      - name: Add version info
-        env:
-          Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
-        run: |
-          sed -i "s/$Version (release)/$Version (debug)/g" src/Config.h
-      - name: Build PlatformIO Project esp32dev_dbg
-        run: |
-          pio run --environment esp32dev_dbg
-          mkdir -p debug/esp32dev
-          cp .pio/build/esp32dev_dbg/bootloader.bin debug/esp32dev/bootloader.bin
-          cp .pio/build/esp32dev_dbg/firmware.bin debug/esp32dev/nuki_hub_esp32.bin
-          cp .pio/build/esp32dev_dbg/partitions.bin debug/esp32dev/nuki_hub.partitions.bin
-          cp .pio/build/esp32dev_dbg/firmware.elf debug/esp32dev/nuki_hub_esp32.elf
-          cp bin/boot_app0.bin debug/esp32dev/boot_app0.bin
-          cp how-to-flash.txt debug/esp32dev/how-to-flash.txt
-          echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32dev/flash.sh
-      - name: Build PlatformIO Project esp32-s3_dbg
-        run: |
-          pio run --environment esp32-s3_dbg
-          mkdir -p debug/esp32s3
-          cp .pio/build/esp32-s3_dbg/bootloader.bin debug/esp32s3/bootloader.bin
-          cp .pio/build/esp32-s3_dbg/firmware.bin debug/esp32s3/nuki_hub_esp32s3.bin
-          cp .pio/build/esp32-s3_dbg/partitions.bin debug/esp32s3/nuki_hub.partitions.bin
-          cp .pio/build/esp32-s3_dbg/firmware.elf debug/esp32s3/nuki_hub_esp32s3.elf
-          cp bin/boot_app0.bin debug/esp32s3/boot_app0.bin
-          cp how-to-flash.txt debug/esp32s3/how-to-flash.txt
-          echo "esptool.py --chip esp32s3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32s3.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32s3/flash.sh
-      - name: Build PlatformIO Project esp32-c3_dbg
-        run: |
-          pio run --environment esp32-c3_dbg
-          mkdir -p debug/esp32c3
-          cp .pio/build/esp32-c3_dbg/bootloader.bin debug/esp32c3/bootloader.bin
-          cp .pio/build/esp32-c3_dbg/firmware.bin debug/esp32c3/nuki_hub_esp32c3.bin
-          cp .pio/build/esp32-c3_dbg/partitions.bin debug/esp32c3/nuki_hub.partitions.bin
-          cp .pio/build/esp32-c3_dbg/firmware.elf debug/esp32c3/nuki_hub_esp32c3.elf
-          cp bin/boot_app0.bin debug/esp32c3/boot_app0.bin
-          cp how-to-flash.txt debug/esp32c3/how-to-flash.txt
-          echo "esptool.py --chip esp32c3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32c3.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32c3/flash.sh
-      - name: Build PlatformIO Project esp32solo1_dbg
-        run: |
-          pio run --environment esp32solo1_dbg
-          mkdir -p debug/esp32solo1
-          cp .pio/build/esp32solo1_dbg/bootloader.bin debug/esp32solo1/bootloader.bin
-          cp .pio/build/esp32solo1_dbg/firmware.bin debug/esp32solo1/nuki_hub_esp32solo1.bin
-          cp .pio/build/esp32solo1_dbg/partitions.bin debug/esp32solo1/nuki_hub.partitions.bin
-          cp .pio/build/esp32solo1_dbg/firmware.elf debug/esp32solo1/nuki_hub_esp32solo1.elf
-          cp bin/boot_app0.bin debug/esp32solo1/boot_app0.bin
-          cp how-to-flash.txt debug/esp32solo1/how-to-flash.txt
-          echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32solo1.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32solo1/flash.sh
-      - name: Upload Artifact esp32dev-debug
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32-debug-assets
-          path: debug/esp32dev
-      - name: Upload Artifact esp32-s3-debug
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32-s3-debug-assets
-          path: debug/esp32s3
-      - name: Upload Artifact esp32-c3-debug
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32-c3-debug-assets
-          path: debug/esp32c3
-      - name: Upload Artifact esp32solo1-debug
-        uses: actions/upload-artifact@v4
-        with:
-          name: esp32solo1-debug-assets
-          path: debug/esp32solo1
+          name: ${{ format('{0}-{1}-assets', matrix.name, matrix.build) }}
+          path: ${{ matrix.build }}/${{ matrix.name }}
+
+      # ----
+
+            # echo "esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32.bin 0x8000 nuki_hub.partitions.bin" > debug/esp32dev/flash.sh
+
   release:
     name: Release new version
     needs: build

--- a/how-to-flash.txt
+++ b/how-to-flash.txt
@@ -60,19 +60,19 @@ Howto flash (esptool)
 
 As an alternative to the Download Tools, you can also use the esptool from the Espressif SDK. The command line to flash looks like this:
 
-ESP32
+## ESP32
 
 esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32.bin 0x8000 nuki_hub.partitions.bin
 
-ESP-S3
+## ESP32-S3
 
 esptool.py --chip esp32s3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32s3.bin 0x8000 nuki_hub.partitions.bin
 
-ESP-C3
+## ESP32-C3
 
 esptool.py --chip esp32c3 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x0 bootloader.bin 0x10000 nuki_hub_esp32c3.bin 0x8000 nuki_hub.partitions.bin
 
-ESP32-Solo1
+## ESP32Solo1
 
 esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq keep --flash_size detect 0xe000 boot_app0.bin 0x1000 bootloader.bin 0x10000 nuki_hub_esp32solo1.bin 0x8000 nuki_hub.partitions.bin
 


### PR DESCRIPTION
This is a rework of the `build.yaml` GitHub Actions.
While there are some special stuff that is scripted, this is a good first step in towards simplifying the workflow.
Instead of copy-pasting the build commands, you can add new models by defining into the `matrix`.

## Changes

* Use `matrix.board` to list all boards available, and `matrix.build` for `release` and/or `debug` process.
* Use same `job`, parallelizes machines and drops down the build time from **9 minutes** to less than **2 minutes**.
* Get `flash.sh` command from docs `how-to-flash.txt`, easy to mantain in a single place.


> [!NOTE]  
> Suggest to do an `squash merge`, I don't think you'll need the testing commits.