### PR TITLE
Change ESP32-S3 to 4MB build

### DIFF
--- a/boards/nuki-esp32-s3.json
+++ b/boards/nuki-esp32-s3.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESP32-S3 (4 MB QD, No PSRAM)",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = esp32dev
+boards_dir = boards
 
 [env]
 platform = espressif32
@@ -46,7 +47,7 @@ board = esp32-c3-devkitc-02
 
 [env:esp32-s3]
 extends = env:esp32dev
-board = esp32-s3-devkitc-1
+board = nuki-esp32-s3
 
 [env:esp32solo1]
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.03/platform-espressif32-2023.10.03.zip


### PR DESCRIPTION
## Description:
Builds S3 for devices with 4MB instead of 8MB flash. Smaller flash size should work without problems on devices with more flash, but this does not work the other way around, even when the partition table fits within 4MB.

Tested without issue using both the webflash binary and separate binaries on a S3 with 16MB flash.

**Related issue:** fixes #401 fixes #397 

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).