### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         with:
           prerelease: false
           allowUpdates: true
-          updateOnlyUnreleased: true
+          updateOnlyUnreleased: false
           draft: true
           name: "Nuki Hub ${{ steps.get_version.outputs.VERSION }}"
           artifacts: ${{ steps.zip.outputs.artifacts }}


### PR DESCRIPTION
## Description:

Release workflow fails with `updateOnlyUnreleased: true`

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).