### PR TITLE
Fix nr of retries

### DIFF
--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -64,7 +64,7 @@ void NukiOpenerWrapper::initialize()
     _retryDelay = _preferences->getInt(preference_command_retry_delay);
     _rssiPublishInterval = _preferences->getInt(preference_rssi_publish_interval) * 1000;
 
-    if(_nrOfRetries == 200)
+    if(_nrOfRetries < 0 || _nrOfRetries == 200)
     {
         _nrOfRetries = 3;
         _preferences->putInt(preference_command_nr_of_retries, _nrOfRetries);
@@ -353,7 +353,7 @@ void NukiOpenerWrapper::updateKeyTurnerState()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -438,7 +438,7 @@ void NukiOpenerWrapper::updateBatteryState()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -498,7 +498,7 @@ void NukiOpenerWrapper::updateConfig()
                 Nuki::CmdResult result;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -580,7 +580,7 @@ void NukiOpenerWrapper::updateAuthData(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -657,7 +657,7 @@ void NukiOpenerWrapper::updateKeypad(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -728,7 +728,7 @@ void NukiOpenerWrapper::updateTimeControl(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -1043,7 +1043,7 @@ void NukiOpenerWrapper::onConfigUpdateReceived(const char *value)
                 cmdResult = Nuki::CmdResult::Error;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -1243,7 +1243,7 @@ void NukiOpenerWrapper::onConfigUpdateReceived(const char *value)
                 cmdResult = Nuki::CmdResult::Error;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -1571,7 +1571,7 @@ void NukiOpenerWrapper::onKeypadCommandReceived(const char *command, const uint 
     Nuki::CmdResult result = (Nuki::CmdResult)-1;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -1769,7 +1769,7 @@ void NukiOpenerWrapper::onKeypadJsonCommandReceived(const char *value)
         Nuki::CmdResult result = (Nuki::CmdResult)-1;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -2233,7 +2233,7 @@ void NukiOpenerWrapper::onTimeControlCommandReceived(const char *value)
         Nuki::CmdResult result = (Nuki::CmdResult)-1;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -2458,7 +2458,7 @@ void NukiOpenerWrapper::readConfig()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -2492,7 +2492,7 @@ void NukiOpenerWrapper::readAdvancedConfig()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -2544,7 +2544,7 @@ void NukiOpenerWrapper::disableHASS()
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -87,7 +87,7 @@ void NukiWrapper::initialize(const bool& firstStart)
         _preferences->putBytes(preference_conf_opener_advanced_acl, (byte*)(&advancedOpenerConfigAclPrefs), sizeof(advancedOpenerConfigAclPrefs));
     }
 
-    if(_nrOfRetries == 200)
+    if(_nrOfRetries < 0 || _nrOfRetries == 200)
     {
         _nrOfRetries = 3;
         _preferences->putInt(preference_command_nr_of_retries, _nrOfRetries);
@@ -379,7 +379,7 @@ void NukiWrapper::updateKeyTurnerState()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -441,7 +441,7 @@ void NukiWrapper::updateBatteryState()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -501,7 +501,7 @@ void NukiWrapper::updateConfig()
                 Nuki::CmdResult result;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -583,7 +583,7 @@ void NukiWrapper::updateAuthData(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -660,7 +660,7 @@ void NukiWrapper::updateKeypad(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -731,7 +731,7 @@ void NukiWrapper::updateTimeControl(bool retrieved)
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -1174,7 +1174,7 @@ void NukiWrapper::onConfigUpdateReceived(const char *value)
                 cmdResult = Nuki::CmdResult::Error;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -1396,7 +1396,7 @@ void NukiWrapper::onConfigUpdateReceived(const char *value)
                 cmdResult = Nuki::CmdResult::Error;
                 _retryCount = 0;
 
-                while(_retryCount < _nrOfRetries)
+                while(_retryCount < _nrOfRetries + 1)
                 {
                     int loop = 0;
                     while(_taskRunning && loop < 600)
@@ -1789,7 +1789,7 @@ void NukiWrapper::onKeypadCommandReceived(const char *command, const uint &id, c
     Nuki::CmdResult result = (Nuki::CmdResult)-1;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -1987,7 +1987,7 @@ void NukiWrapper::onKeypadJsonCommandReceived(const char *value)
         Nuki::CmdResult result = (Nuki::CmdResult)-1;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -2451,7 +2451,7 @@ void NukiWrapper::onTimeControlCommandReceived(const char *value)
         Nuki::CmdResult result = (Nuki::CmdResult)-1;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)
@@ -2677,7 +2677,7 @@ void NukiWrapper::readConfig()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -2709,7 +2709,7 @@ void NukiWrapper::readAdvancedConfig()
     Nuki::CmdResult result;
     _retryCount = 0;
 
-    while(_retryCount < _nrOfRetries)
+    while(_retryCount < _nrOfRetries + 1)
     {
         int loop = 0;
         while(_taskRunning && loop < 600)
@@ -2765,7 +2765,7 @@ void NukiWrapper::disableHASS()
         Nuki::CmdResult result;
         _retryCount = 0;
 
-        while(_retryCount < _nrOfRetries)
+        while(_retryCount < _nrOfRetries + 1)
         {
             int loop = 0;
             while(_taskRunning && loop < 600)


### PR DESCRIPTION
## Description:

In 8.35 when number of retries is set to 0 no commands will be executed (except lock actions)

**Related issue (if applicable):** fixes #406 

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).