### PR TITLE
Allow auto update to beta firmware

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -11,19 +11,29 @@
 #if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define GITHUB_LATEST_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_esp32c3.bin"
 #define GITHUB_LATEST_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_updater_esp32c3.bin"
+#define GITHUB_BETA_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32c3.bin"
+#define GITHUB_BETA_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_updater_esp32c3.bin"
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
 #define GITHUB_LATEST_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_esp32s3.bin"
 #define GITHUB_LATEST_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_updater_esp32s3.bin"
+#define GITHUB_BETA_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32s3.bin"
+#define GITHUB_BETA_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_updater_esp32s3.bin"
 #elif defined(CONFIG_IDF_TARGET_ESP32C6)
 #define GITHUB_LATEST_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_esp32c6.bin"
 #define GITHUB_LATEST_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_updater_esp32c6.bin"
+#define GITHUB_BETA_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32c6.bin"
+#define GITHUB_BETA_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_updater_esp32c6.bin"
 #else
 #if defined(FRAMEWORK_ARDUINO_SOLO1)
 #define GITHUB_LATEST_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_esp32solo1.bin"
 #define GITHUB_LATEST_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_updater_esp32solo1.bin"
+#define GITHUB_BETA_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32solo1.bin"
+#define GITHUB_BETA_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_updater_esp32solo1.bin"
 #else
 #define GITHUB_LATEST_RELEASE_BINARY_URL "https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_esp32.bin"
 #define GITHUB_LATEST_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/nuki_hub_updater_esp32.bin"
+#define GITHUB_BETA_RELEASE_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32.bin"
+#define GITHUB_BETA_UPDATER_BINARY_URL (char*)"https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_updater_esp32.bin"
 #endif
 #endif
 

--- a/src/WebCfgServer.cpp
+++ b/src/WebCfgServer.cpp
@@ -321,11 +321,21 @@ void WebCfgServer::initialize()
         if (_hasCredentials && !_server.authenticate(_credUser, _credPassword)) {
             return _server.requestAuthentication();
         }
-        String response = "";
-        buildConfirmHtml(response, "Rebooting to update Nuki Hub and Nuki Hub updater", 2);
+        String response = "";        
+        String key = _server.argName(0);
+        if(key == "beta")
+        {
+            buildConfirmHtml(response, "Rebooting to update Nuki Hub and Nuki Hub updater<br/>Updating to latest BETA version", 2);
+            _preferences->putString(preference_ota_updater_url, GITHUB_BETA_UPDATER_BINARY_URL);
+            _preferences->putString(preference_ota_main_url, GITHUB_BETA_RELEASE_BINARY_URL);
+        }
+        else
+        {
+            buildConfirmHtml(response, "Rebooting to update Nuki Hub and Nuki Hub updater<br/>Updating to latest RELEASE version", 2);
+            _preferences->putString(preference_ota_updater_url, GITHUB_LATEST_UPDATER_BINARY_URL);
+            _preferences->putString(preference_ota_main_url, GITHUB_LATEST_RELEASE_BINARY_URL);
+        }
         _server.send(200, "text/html", response);
-        _preferences->putString(preference_ota_updater_url, GITHUB_LATEST_UPDATER_BINARY_URL);
-        _preferences->putString(preference_ota_main_url, GITHUB_LATEST_RELEASE_BINARY_URL);
         restartEsp(RestartReason::OTAReboot);
     });
     #endif
@@ -393,7 +403,7 @@ void WebCfgServer::buildOtaHtml(String &response, bool errored)
         response.concat("', '_blank'); return false;\">Open latest release on GitHub</button>");
         return;
     }
-    
+
     response.concat("<div id=\"msgdiv\" style=\"visibility:hidden\">Initiating Over-the-air update. This will take about two minutes, please be patient.<br>You will be forwarded automatically when the update is complete.</div>");
 
     #if (ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(5, 0, 0))


### PR DESCRIPTION
## Description:

Allow updating to beta firmware by browsing to `http://NUKIHUBIP/autoupdate?beta`
Beta firmware to be placed at `https://github.com/technyon/nuki_hub/raw/master/ota/beta/nuki_hub_esp32[device].bin`
When this is merged in 8.36 it can be used in beta testing for 8.37

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).