### PR TITLE
Create release using Github Actions manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
         run: |
-          sed -i "s/unknownbuildnr/$Version (${BUILD})/g" src/Config.h
+          sed -i "s/unknownbuildnr/$Version/g" src/Config.h
       - name: Build ${{ matrix.build }} PlatformIO Project ${{ matrix.board }}
         run: |
           if [ "$BUILD" = "debug" ]; then
@@ -95,97 +95,3 @@ jobs:
         with:
           name: ${{ format('{0}-{1}-assets', env.VARIANT, matrix.build) }}
           path: ${{ matrix.build }}/${{ env.VARIANT }}
-  release:
-    name: Release new version
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
-      - name: Git Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Download release assets
-        uses: actions/download-artifact@v4
-        with:
-          path: release
-          pattern: '*-release-assets'
-      - name: Download debug assets
-        uses: actions/download-artifact@v4
-        with:
-          path: debug
-          pattern: '*-debug-assets'
-      - name: Build zip archives
-        id: zip
-        env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-        run: |
-          NUKI="NukiHub-${VERSION}"
-          ARTIFACTS=""
-
-          for FOLDER in release/*; do
-            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
-            ZIPFILE="${NUKI}-${MODEL}.zip"
-
-            echo "${FOLDER} -- ${ZIPFILE}"
-            cd $FOLDER
-
-            zip -9r ../../${ZIPFILE} * -x "webflash_nuki_hub_*.bin"
-            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
-
-            cd ../..
-          done
-
-          for FOLDER in debug/*; do
-            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
-            ZIPFILE="${NUKI}-${MODEL}-DEBUG.zip"
-
-            echo "${FOLDER} -- ${ZIPFILE}"
-            cd $FOLDER
-
-            zip -9r ../../${ZIPFILE} *
-            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
-
-            cd ../..
-          done
-
-          # remove last character
-          ARTIFACTS="${ARTIFACTS%?}"
-          echo "artifacts=${ARTIFACTS}" | tee -a ${GITHUB_OUTPUT}
-      - name: Create Release
-        id: create_release
-        uses: ncipollo/release-action@v1
-        with:
-          prerelease: false
-          allowUpdates: true
-          updateOnlyUnreleased: false
-          draft: true
-          name: "Nuki Hub ${{ steps.get_version.outputs.VERSION }}"
-          artifacts: ${{ steps.zip.outputs.artifacts }}
-          artifactContentType: application/zip
-      - name: Copy binaries to ota and webflash and remove beta
-        env:
-          Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
-        run: |
-          cp -vf release/*/nuki_hub_*.bin ota/
-          cp -vf release/*/webflash_nuki_hub_*.bin webflash/
-          rm -rf release
-          rm -rf debug
-          rm -rf NukiHub-*.zip
-          git rm -r --cached ota/beta/*.bin
-          python3 resources/ota_manifest.py release $Version
-          python3 resources/ota_manifest.py beta none
-      - name: Commit binaries to master
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Update binaries for version ${{ steps.get_version.outputs.VERSION }}"
-          file_pattern: 'ota/*.bin ota/manifest.json ota/beta/*.bin webflash/*.bin'
-          branch: master
-          skip_dirty_check: true    
-          skip_fetch: true    
-          skip_checkout: true
-          disable_globbing: true
-          add_options: '-f'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
         run: |
-          sed -i "s/unknownbuildnr/$Version (${BUILD})/g" src/Config.h
+          sed -i "s/unknownbuildnr/$Version/g" src/Config.h
       - name: Build ${{ matrix.build }} PlatformIO Project ${{ matrix.board }}
         run: |
           if [ "$BUILD" = "debug" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: NukiHub Beta
+name: NukiHub Release
 on:
   workflow_dispatch:
 
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         board: [esp32dev, esp32-s3, esp32-c3, esp32-c6, esp32solo1]
-        build: [release]
+        build: [release, debug]
     env:
       BOARD: ${{ matrix.board }}
       VARIANT: ${{ matrix.name || matrix.board }}
@@ -89,8 +89,8 @@ jobs:
         with:
           name: ${{ format('{0}-{1}-assets', env.VARIANT, matrix.build) }}
           path: ${{ matrix.build }}/${{ env.VARIANT }}
-  ota-beta:
-    name: Create beta from latest master
+  release:
+    name: Release new version
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -98,24 +98,88 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=$(cat src/Config.h | grep -oP '(?<=#define NUKI_HUB_VERSION \")(.*)(?=\")')" >> $GITHUB_OUTPUT
       - name: Download release assets
         uses: actions/download-artifact@v4
         with:
           path: release
           pattern: '*-release-assets'
-      - name: Copy binaries to ota/beta
+      - name: Download debug assets
+        uses: actions/download-artifact@v4
+        with:
+          path: debug
+          pattern: '*-debug-assets'
+      - name: Build zip archives
+        id: zip
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          NUKI="NukiHub-${VERSION}"
+          ARTIFACTS=""
+
+          for FOLDER in release/*; do
+            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
+            ZIPFILE="${NUKI}-${MODEL}.zip"
+
+            echo "${FOLDER} -- ${ZIPFILE}"
+            cd $FOLDER
+
+            zip -9r ../../${ZIPFILE} * -x "webflash_nuki_hub_*.bin"
+            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
+
+            cd ../..
+          done
+
+          for FOLDER in debug/*; do
+            MODEL=`echo "${FOLDER}" | cut -d '/' -f2 | cut -d '-' -f1 | tr '[:lower:]' '[:upper:]'`
+            ZIPFILE="${NUKI}-${MODEL}-DEBUG.zip"
+
+            echo "${FOLDER} -- ${ZIPFILE}"
+            cd $FOLDER
+
+            zip -9r ../../${ZIPFILE} *
+            ARTIFACTS="${ARTIFACTS}${ZIPFILE},"
+
+            cd ../..
+          done
+
+          # remove last character
+          ARTIFACTS="${ARTIFACTS%?}"
+          echo "artifacts=${ARTIFACTS}" | tee -a ${GITHUB_OUTPUT}
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: false
+          allowUpdates: true
+          updateOnlyUnreleased: false
+          draft: false
+          generateReleaseNotes: true
+          makeLatest: true
+          name: "Nuki Hub ${{ steps.get_version.outputs.VERSION }}"
+          artifactErrorsFailBuild: true
+          artifacts: ${{ steps.zip.outputs.artifacts }}
+          artifactContentType: application/zip
+          tag: ${{ steps.get_version.outputs.VERSION }}
+      - name: Copy binaries to ota and webflash and remove beta
         env:
           Version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
         run: |
-          mkdir -p ota/beta/
-          cp -vf release/*/nuki_hub_*.bin ota/beta/
+          cp -vf release/*/nuki_hub_*.bin ota/
+          cp -vf release/*/webflash_nuki_hub_*.bin webflash/
           rm -rf release
-          python3 resources/ota_manifest.py beta $Version
+          rm -rf debug
+          rm -rf NukiHub-*.zip
+          git rm -r --cached ota/beta/*.bin
+          python3 resources/ota_manifest.py release $Version
+          python3 resources/ota_manifest.py beta none
       - name: Commit binaries to master
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Update beta binaries"
-          file_pattern: 'ota/beta/*.bin ota/manifest.json'
+          commit_message: "Update binaries for version ${{ steps.get_version.outputs.VERSION }}"
+          file_pattern: 'ota/*.bin ota/manifest.json ota/beta/*.bin webflash/*.bin'
           branch: master
           skip_dirty_check: true
           skip_fetch: true


### PR DESCRIPTION
## Description:

Allow creating a release using Github Actions without manually creating a tag

Release can be created by going to Github -> Actions -> Nuki Hub Release -> Run workflow -> Run workflow

![image](https://github.com/user-attachments/assets/2dc4dbea-34d6-47c2-a113-b27e08de8ec9)

Will create a tag and release based on the version number in Config.h and auto create release notes based on PR's since latest tag/release.

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).