### PR TITLE
Hybrid mode fixes

### DIFF
--- a/HYBRID.md
+++ b/HYBRID.md
@@ -43,7 +43,7 @@ The Hybrid Official MQTT over Thread + Nuki Hub solution allows for the best com
 - Enable `Enable hybrid official MQTT and Nuki Hub setup`. The `Lock: Nuki Bridge is running alongside Nuki Hub (needs re-pairing if changed)` setting will be automatically be enabled.
 - Optionally enable `Enable sending actions through official MQTT`, if not enabled lock actions will be sent over BLE as usual (slower)
 - Set `Time between status updates when official MQTT is offline (seconds)` to a positive integer. If the Nuki lock MQTT connection goes offline for whatever reason Nuki Hub will update the lock state with the set interval in seconds.
-- Optionally enable `Retry command sent using official MQTT over BLE if failed`. If sending a lock action over the official MQTT implementation fails the command will be resent over BLE if this is enabled. Requires `Enable sending actions through official MQTT` to be enabled.
+<!--- Optionally enable `Retry command sent using official MQTT over BLE if failed`. If sending a lock action over the official MQTT implementation fails the command will be resent over BLE if this is enabled. Requires `Enable sending actions through official MQTT` to be enabled.!-->
 - Save your configuration
 - Consider setting the `Query intervals` on the `Advanced Nuki configuration` to high numbers (e.g. 86400) to further reduce battery drain.
 - Pair your Nuki Lock with Nuki Hub

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -960,9 +960,16 @@ LockActionResult NukiWrapper::onLockActionReceivedCallback(const char *value)
         if(!networkInst->_offConnected) nukiInst->_nextLockAction = action;
         else
         {
-            networkInst->_offCommandExecutedTs = (esp_timer_get_time() / 1000) + 2000;
-            networkInst->_offCommand = action;
-            networkInst->publishOffAction((int)action);
+            if(nukiLockPreferences->getBool(preference_official_hybrid_actions, false)) 
+            {
+                networkInst->_offCommandExecutedTs = (esp_timer_get_time() / 1000) + 2000;
+                networkInst->_offCommand = action;
+                networkInst->publishOffAction((int)action);
+            }
+            else
+            {
+                nukiInst->_nextLockAction = action;
+            }
         }
         nukiLockPreferences->end();
         return LockActionResult::Success;

--- a/src/WebCfgServer.cpp
+++ b/src/WebCfgServer.cpp
@@ -2748,7 +2748,7 @@ void WebCfgServer::buildMqttConfigHtml(AsyncWebServerRequest *request)
     printCheckBox("OFFHYBRID", "Enable hybrid official MQTT and Nuki Hub setup", _preferences->getBool(preference_official_hybrid), "");
     printCheckBox("HYBRIDACT", "Enable sending actions through official MQTT", _preferences->getBool(preference_official_hybrid_actions), "");
     printInputField("HYBRIDTIMER", "Time between status updates when official MQTT is offline (seconds)", _preferences->getInt(preference_query_interval_hybrid_lockstate), 5, "");
-    printCheckBox("HYBRIDRETRY", "Retry command sent using official MQTT over BLE if failed", _preferences->getBool(preference_official_hybrid_retry), "");
+    // printCheckBox("HYBRIDRETRY", "Retry command sent using official MQTT over BLE if failed", _preferences->getBool(preference_official_hybrid_retry), ""); // NOT IMPLEMENTED (YET?)
     _response.concat("</table>");
     _response.concat("* If no encryption is configured for the MQTT broker, leave empty.<br><br>");
 
@@ -3419,11 +3419,13 @@ void WebCfgServer::buildInfoHtml(AsyncWebServerRequest *request)
             _response.concat(_nuki->offConnected() ? "Yes": "No");
             _response.concat("\nSending actions through official MQTT enabled: ");
             _response.concat(_preferences->getBool(preference_official_hybrid_actions, false) ? "Yes" : "No");
+            /* NOT IMPLEMENTED (YET?)
             if(_preferences->getBool(preference_official_hybrid_actions, false))
             {
                 _response.concat("\nRetry actions through BLE enabled: ");
                 _response.concat(_preferences->getBool(preference_official_hybrid_retry, false) ? "Yes" : "No");
             }
+            */
             _response.concat("\nTime between status updates when official MQTT is offline (s): ");
             _response.concat(_preferences->getInt(preference_query_interval_hybrid_lockstate, 600));
         }


### PR DESCRIPTION
## Description:

-Actually respect value of `Sending actions through official MQTT` in Hybrid mode (was in fact always enabled when hybrid mode was enabled)
-Remove setting `Retry actions through BLE` in Hybrid mode as this is not implemented at this time

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).