### PR TITLE
Conform to Home Assistant Discovery Spec

### DIFF
--- a/src/NukiNetwork.cpp
+++ b/src/NukiNetwork.cpp
@@ -874,7 +874,7 @@ void NukiNetwork::publishHASSConfig(char* deviceType, const char* baseTopic, cha
     json["name"] = nullptr;
     json["unique_id"] = String(uidString) + "_lock";
     json["cmd_t"] = String("~") + String(mqtt_topic_lock_action);
-    json["avty"]["t"] = availabilityTopic;
+    json["avty_t"] = availabilityTopic;
     json["pl_lock"] = lockAction;
     json["pl_unlk"] = unlockAction;
 


### PR DESCRIPTION
## Description:

`availability` is documented as a list (of objects), not a single object. Just use the simpler availability_topic instead.

Fixes https://github.com/openhab/openhab-addons/issues/17375

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
