### PR TITLE
Add requirement for Nuki Lock pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In that case leave all fields starting with "MQTT SSL" blank. Otherwise see the 
 
 ## Pairing with a Nuki Lock or Opener
 
-Enable pairing mode on the Nuki Lock or Opener (press the button on the Nuki device for a few seconds) and power on the ESP32.<br>
+Enable pairing mode on the Nuki Lock or Opener (press the button on the Nuki device for a few seconds - make sure Bluetooth pairing is allowed for the Nuki Lock button before) and power on the ESP32.<br>
 Pairing should be automatic.<br>
 <br>
 When pairing is successful, the web interface should show "Paired: Yes".<br>

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ In that case leave all fields starting with "MQTT SSL" blank. Otherwise see the 
 
 ## Pairing with a Nuki Lock or Opener
 
-Enable pairing mode on the Nuki Lock or Opener (press the button on the Nuki device for a few seconds - make sure Bluetooth pairing is allowed for the Nuki Lock button before) and power on the ESP32.<br>
-Pairing should be automatic.<br>
+Make sure "Bluetooth pairing" is enabled for the Nuki device by enabling this setting in the official Nuki App in "Settings" > "Features & Configuration" > "Button and LED".
+After enabling the setting press the button on the Nuki device for a few seconds.<br>
+Pairing should be automatic when the ESP32 is powered on.<br>
 <br>
 When pairing is successful, the web interface should show "Paired: Yes".<br>
 MQTT nodes like lock state and battery level should now reflect the reported values from the lock.<br>


### PR DESCRIPTION
With "Bluetooth Pairing" disabled for a Nuki Lock, pairing Nuki Hub via button is not possible. Readme reflects this now.

## Description:

**Related issue (if applicable):** fixes #<Nuki Hub issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest master branch
  - [X] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works
  - [X] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
