### PR TITLE
chore: update log entry for HTTP_EVENT_ON_DATA

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,7 +344,7 @@ esp_err_t _http_event_handler(esp_http_client_event_t *evt)
         Log->println("HTTP_EVENT_ON_HEADER");
         break;
     case HTTP_EVENT_ON_DATA:
-        Log->println("HTTP_EVENT_ON_DATA");
+        Log->print(".");
         break;
     case HTTP_EVENT_ON_FINISH:
         Log->println("HTTP_EVENT_ON_FINISH");


### PR DESCRIPTION
## Description:

During OTA upgrade, this text is repeated on every event execution, causing lots of line entries.
Unless it has any other purpose, I suggest to shorten it with a dot `[.]` for every event match.

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
