### PR TITLE
Refactor retry handling

### DIFF
--- a/clion/CMakeLists.txt
+++ b/clion/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRCFILES
         ../lib/BleScanner/src/BleScanner.cpp
         ../lib/MqttLogger/src/MqttLogger.cpp
         ../src/util/NetworkUtil.cpp
+        ../src/util/NukiRetryHandler.cpp
         ../src/enums/NetworkDeviceType.h
         ../src/util/NetworkDeviceInstantiator.cpp
         ../src/HomeAssistantDiscovery.cpp

--- a/src/Config.h
+++ b/src/Config.h
@@ -5,8 +5,8 @@
 #define NUKI_HUB_VERSION "9.13"
 #define NUKI_HUB_VERSION_INT (uint32_t)913
 #define NUKI_HUB_BUILD "unknownbuildnr"
-#define NUKI_HUB_DATE "2025-10-02"
-#define NUKI_HUB_DATE "2025-10-02"
+#define NUKI_HUB_DATE "2025-10-05"
+#define NUKI_HUB_DATE "2025-10-05"
 
 #define GITHUB_LATEST_RELEASE_URL (char*)"https://github.com/technyon/nuki_hub/releases/latest"
 #define GITHUB_OTA_MANIFEST_URL (char*)"https://raw.githubusercontent.com/technyon/nuki_hub/binary/ota/manifest.json"

--- a/src/NukiNetwork.cpp
+++ b/src/NukiNetwork.cpp
@@ -806,7 +806,7 @@ bool NukiNetwork::reconnect(bool force)
         if (_device->mqttConnected())
         {
             Log->println("MQTT connected");
-            _mqttConnectedTs = millis();
+            _mqttConnectedTs = espMillis();
             _mqttConnectionState = 1;
             if (esp_task_wdt_status(NULL) == ESP_OK)
             {

--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -979,7 +979,7 @@ void NukiOpenerWrapper::updateAuth(bool retrieved)
 
         if(result == Nuki::CmdResult::Success)
         {
-            _waitAuthUpdateTs = millis() + 5000;
+            _waitAuthUpdateTs = espMillis() + 5000;
         }
     }
     else

--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -541,6 +541,7 @@ bool NukiOpenerWrapper::updateKeyTurnerState()
 {
     bool updateStatus = false;
     Nuki::CmdResult result = (Nuki::CmdResult)-1;
+    Log->println("Querying opener state");
 
     result = _nukiRetryHandler->retryComm([&]()
     {
@@ -3763,7 +3764,10 @@ void NukiOpenerWrapper::updateTime()
     nukiTime.minute = tm.tm_min;
     nukiTime.second = tm.tm_sec;
 
-    Nuki::CmdResult cmdResult = _nukiOpener.updateTime(nukiTime);
+    Nuki::CmdResult cmdResult = _nukiRetryHandler->retryComm([&]()
+    {
+        return _nukiOpener.updateTime(nukiTime);
+    });
 
     char resultStr[15] = {0};
     NukiOpener::cmdResultToString(cmdResult, resultStr);

--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -289,44 +289,6 @@ void NukiOpenerWrapper::update()
 
     if(_nextLockAction != (NukiOpener::LockAction)0xff)
     {
-        // int retryCount = 0;
-        // Nuki::CmdResult cmdResult = (Nuki::CmdResult)-1;
-        //
-        // while(retryCount < _nrOfRetries + 1 && cmdResult != Nuki::CmdResult::Success)
-        // {
-        //     cmdResult = _nukiOpener.lockAction(_nextLockAction, 0, 0);
-        //     char resultStr[15] = {0};
-        //     NukiOpener::cmdResultToString(cmdResult, resultStr);
-        //
-        //     _network->publishCommandResult(resultStr);
-        //
-        //     Log->print("Opener action result: ");
-        //     Log->println(resultStr);
-        //
-        //     if(cmdResult != Nuki::CmdResult::Success)
-        //     {
-        //         setCommErrorPins(HIGH);
-        //         Log->print("Opener: Last command failed, retrying after ");
-        //         Log->print(_retryDelay);
-        //         Log->print(" milliseconds. Retry ");
-        //         Log->print(retryCount + 1);
-        //         Log->print(" of ");
-        //         Log->println(_nrOfRetries);
-        //
-        //         _network->publishRetry(std::to_string(retryCount + 1));
-        //
-        //         if (esp_task_wdt_status(NULL) == ESP_OK)
-        //         {
-        //             esp_task_wdt_reset();
-        //         }
-        //         vTaskDelay(_retryDelay / portTICK_PERIOD_MS);
-        //
-        //         ++retryCount;
-        //     }
-        //     postponeBleWatchdog();
-        // }
-        // setCommErrorPins(LOW);
-
         int retryCount = 0;
 
         Nuki::CmdResult result = _nukiRetryHandler->retryComm([&]()

--- a/src/NukiOpenerWrapper.h
+++ b/src/NukiOpenerWrapper.h
@@ -7,6 +7,7 @@
 #include "BleScanner.h"
 #include "Gpio.h"
 #include "NukiDeviceId.h"
+#include "util/NukiRetryHandler.h"
 
 class NukiOpenerWrapper : public NukiOpener::SmartlockEventHandler
 {
@@ -85,6 +86,7 @@ private:
     NukiNetworkOpener* _network = nullptr;
     Preferences* _preferences = nullptr;
     Gpio* _gpio = nullptr;
+    NukiRetryHandler* _nukiRetryHandler = nullptr;
 
     std::vector<uint8_t> _pinsCommError;
 

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -80,7 +80,7 @@ void NukiWrapper::initialize()
     readSettings();
 
 #ifndef NUKI_HUB_UPDATER
-    _nukiRetryHandler = new NukiRetryHandler(_gpio, _gpio->getPinsWithRole(PinRole::OutputHighBluetoothCommError), _nrOfRetries, _retryDelay);
+    _nukiRetryHandler = new NukiRetryHandler("Lock", _gpio, _gpio->getPinsWithRole(PinRole::OutputHighBluetoothCommError), _nrOfRetries, _retryDelay);
 #endif
 }
 
@@ -336,39 +336,6 @@ void NukiWrapper::update(bool reboot)
 
             return cmdResult;
         });
-
-        // while(retryCount < _nrOfRetries + 1 && cmdResult != Nuki::CmdResult::Success)
-        // {
-        //     cmdResult = _nukiLock.lockAction(_nextLockAction, 0, 0);
-        //     char resultStr[15] = {0};
-        //     NukiLock::cmdResultToString(cmdResult, resultStr);
-        //     _network->publishCommandResult(resultStr);
-        //
-        //     Log->print("Lock action result: ");
-        //     Log->println(resultStr);
-        //
-        //     if(cmdResult != Nuki::CmdResult::Success)
-        //     {
-        //         setCommErrorPins(HIGH);
-        //         Log->print("Lock: Last command failed, retrying after ");
-        //         Log->print(_retryDelay);
-        //         Log->print(" milliseconds. Retry ");
-        //         Log->print(retryCount + 1);
-        //         Log->print(" of ");
-        //         Log->println(_nrOfRetries);
-        //
-        //         _network->publishRetry(std::to_string(retryCount + 1));
-        //
-        //         if (esp_task_wdt_status(NULL) == ESP_OK)
-        //         {
-        //             esp_task_wdt_reset();
-        //         }
-        //         vTaskDelay(_retryDelay / portTICK_PERIOD_MS);
-        //
-        //         ++retryCount;
-        //     }
-        //     postponeBleWatchdog();
-        // }
 
         if(result == Nuki::CmdResult::Success)
         {

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -1145,7 +1145,7 @@ void NukiWrapper::updateAuth(bool retrieved)
         NukiHelper::printCommandResult(result);
         if(result == Nuki::CmdResult::Success)
         {
-            _waitAuthUpdateTs = millis() + 5000;
+            _waitAuthUpdateTs = espMillis() + 5000;
         }
     }
     else

--- a/src/NukiWrapper.h
+++ b/src/NukiWrapper.h
@@ -10,6 +10,7 @@
 #include "NukiDeviceId.h"
 #include "NukiOfficial.h"
 #include "EspMillis.h"
+#include "util/NukiRetryHandler.h"
 
 class NukiWrapper : public Nuki::SmartlockEventHandler
 {
@@ -48,7 +49,6 @@ public:
     const std::string firmwareVersion() const;
     const std::string hardwareVersion() const;
 
-    void setCommErrorPins(const uint8_t& value);
 
     void notify(Nuki::EventType eventType) override;
 
@@ -93,8 +93,7 @@ private:
     NukiNetworkLock* _network = nullptr;
     NukiOfficial* _nukiOfficial = nullptr;
     Gpio* _gpio = nullptr;
-
-    std::vector<uint8_t> _pinsCommError;
+    NukiRetryHandler* _nukiRetryHandler = nullptr;
 
     Preferences* _preferences;
     int _intervalLockstate = 0; // seconds

--- a/src/util/NukiRetryHandler.cpp
+++ b/src/util/NukiRetryHandler.cpp
@@ -1,0 +1,50 @@
+#include "NukiRetryHandler.h"
+#include "Logger.h"
+
+NukiRetryHandler::NukiRetryHandler(Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay)
+: _gpio(gpio),
+  _pinsCommError(pinsCommError),
+  _nrOfRetries(nrOfRetries),
+  _retryDelay(retryDelay)
+{
+}
+
+const Nuki::CmdResult NukiRetryHandler::retryComm(std::function<Nuki::CmdResult()> func)
+{
+    Nuki::CmdResult cmdResult = Nuki::CmdResult::Error;
+
+    int retryCount = 0;
+
+    while(retryCount < _nrOfRetries + 1 && cmdResult != Nuki::CmdResult::Success)
+    {
+        cmdResult = func();
+
+        if (cmdResult != Nuki::CmdResult::Success)
+        {
+            setCommErrorPins(HIGH);
+            ++retryCount;
+
+            Log->print("Lock: Last command failed, retrying after ");
+            Log->print(_retryDelay);
+            Log->print(" milliseconds. Retry ");
+            Log->print(retryCount);
+            Log->print(" of ");
+            Log->println(_nrOfRetries);
+
+            vTaskDelay(_retryDelay / portTICK_PERIOD_MS);
+        }
+    }
+    setCommErrorPins(LOW);
+
+    return cmdResult;
+}
+
+void NukiRetryHandler::setCommErrorPins(const uint8_t& value)
+{
+    for (uint8_t pin : _pinsCommError)
+    {
+        _gpio->setPinOutput(pin, value);
+    }
+}
+
+

--- a/src/util/NukiRetryHandler.cpp
+++ b/src/util/NukiRetryHandler.cpp
@@ -1,8 +1,9 @@
 #include "NukiRetryHandler.h"
 #include "Logger.h"
 
-NukiRetryHandler::NukiRetryHandler(Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay)
-: _gpio(gpio),
+NukiRetryHandler::NukiRetryHandler(std::string reference, Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay)
+: _reference(reference),
+  _gpio(gpio),
   _pinsCommError(pinsCommError),
   _nrOfRetries(nrOfRetries),
   _retryDelay(retryDelay)
@@ -24,7 +25,8 @@ const Nuki::CmdResult NukiRetryHandler::retryComm(std::function<Nuki::CmdResult(
             setCommErrorPins(HIGH);
             ++retryCount;
 
-            Log->print("Lock: Last command failed, retrying after ");
+            Log->print(_reference.c_str());
+            Log->print(": Last command failed, retrying after ");
             Log->print(_retryDelay);
             Log->print(" milliseconds. Retry ");
             Log->print(retryCount);

--- a/src/util/NukiRetryHandler.h
+++ b/src/util/NukiRetryHandler.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <functional>
+#include "NukiDataTypes.h"
+#include "NukiPublisher.h"
+
+class NukiRetryHandler
+{
+public:
+    NukiRetryHandler(Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay);
+
+    const Nuki::CmdResult retryComm(std::function<Nuki::CmdResult ()> func);
+
+
+private:
+    void setCommErrorPins(const uint8_t& value);
+
+    Gpio* _gpio = nullptr;
+    int _nrOfRetries = 0;
+    int _retryDelay = 0;
+    std::vector<uint8_t> _pinsCommError;
+};

--- a/src/util/NukiRetryHandler.h
+++ b/src/util/NukiRetryHandler.h
@@ -6,7 +6,7 @@
 class NukiRetryHandler
 {
 public:
-    NukiRetryHandler(Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay);
+    NukiRetryHandler(std::string reference, Gpio* gpio, std::vector<uint8_t> pinsCommError, int nrOfRetries, int retryDelay);
 
     const Nuki::CmdResult retryComm(std::function<Nuki::CmdResult ()> func);
 
@@ -14,6 +14,7 @@ public:
 private:
     void setCommErrorPins(const uint8_t& value);
 
+    std::string _reference;
     Gpio* _gpio = nullptr;
     int _nrOfRetries = 0;
     int _retryDelay = 0;


### PR DESCRIPTION
The nuki wrapper classes have many occurences of while loops to retry communication. This PR wraps this into a single NukiRetryWrapper class to reduce code duplication. Also handles gpio pins associated with communication.