### PR TITLE
Add recalibrate functionality to Home Assistant

### DIFF
--- a/src/HomeAssistantDiscovery.cpp
+++ b/src/HomeAssistantDiscovery.cpp
@@ -901,6 +901,25 @@ void HomeAssistantDiscovery::publishHASSConfigAdditionalLockEntities(char *devic
         { (char*)"pl_prs", (char*)"1" }
     });
 
+    // Recalibrate
+    publishHassTopic("button",
+                     "recalibrate",
+                     uidString,
+                     "_recalibrate",
+                     "Recalibrate",
+                     name,
+                     baseTopic,
+                     "",
+                     deviceType,
+                     "",
+                     "",
+                     "config",
+                     String("~") + mqtt_topic_lock_action,
+    {
+        { (char*)"en", (char*)"true" },
+        { (char*)"pl_prs", (char*)"recalibrate" }
+    });
+
     if((int)basicLockConfigAclPrefs[6] == 1)
     {
         // LED enabled
@@ -2039,6 +2058,25 @@ void HomeAssistantDiscovery::publishHASSConfigAdditionalOpenerEntities(char *dev
     {
         removeHassTopic((char*)"button", (char*)"unlatch", uidString);
     }
+
+    // Recalibrate
+    publishHassTopic("button",
+                     "recalibrate",
+                     uidString,
+                     "_recalibrate",
+                     "Recalibrate",
+                     name,
+                     baseTopic,
+                     "",
+                     deviceType,
+                     "",
+                     "",
+                     "config",
+                     String("~") + mqtt_topic_lock_action,
+    {
+        { (char*)"en", (char*)"true" },
+        { (char*)"pl_prs", (char*)"recalibrate" }
+    });
 
     publishHassTopic("binary_sensor",
                      "continuous_mode",

--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -1010,6 +1010,18 @@ void NukiOpenerWrapper::postponeBleWatchdog()
 
 LockActionResult NukiOpenerWrapper::onLockActionReceivedCallback(const char *value)
 {
+    if (value != nullptr && strcmp(value, "recalibrate") == 0)
+    {
+        if(!nukiOpenerInst->isPinValid())
+        {
+            Log->println("PIN not valid, cannot recalibrate");
+            return LockActionResult::AccessDenied;
+        }
+        Log->println("Recalibrating");
+        nukiOpenerInst->_nukiOpener.requestCalibration();
+        return LockActionResult::Success;
+    }
+
     NukiOpener::LockAction action;
 
     if(value)

--- a/src/NukiWrapper.cpp
+++ b/src/NukiWrapper.cpp
@@ -1189,6 +1189,18 @@ LockActionResult NukiWrapper::onLockActionReceivedCallback(const char *value)
 
 LockActionResult NukiWrapper::onLockActionReceived(const char *value)
 {
+    if (value != nullptr && strcmp(value, "recalibrate") == 0)
+    {
+        if(!isPinValid())
+        {
+            Log->println("PIN not valid, cannot recalibrate");
+            return LockActionResult::AccessDenied;
+        }
+        Log->println("Recalibrating");
+        _nukiLock.requestCalibration();
+        return LockActionResult::Success;
+    }
+
     NukiLock::LockAction action;
 
     if(value)


### PR DESCRIPTION
## Description:

I own a Nuki Ultra that requires frequent recalibration. To avoid relying on the official Nuki App for this maintenance task, I implemented a feature to expose a recalibration entity directly in Home Assistant.

This change allows users to trigger the recalibration manually via HA or create custom automations (e.g., trigger based on door events).

I believed this functionality would be beneficial for other users facing similar calibration issues.

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
