### PR TITLE
Improved opener ring behaviour

### DIFF
--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -543,25 +543,37 @@ bool NukiOpenerWrapper::updateKeyTurnerState()
 
     if((!isPinValid() || !_publishAuthData) &&
             _statusUpdated &&
+            _keyTurnerState.nukiState == NukiOpener::State::ContinuousMode &&
+            _keyTurnerState.trigger == NukiOpener::Trigger::Manual &&
+            (_keyTurnerState.lockState == NukiOpener::LockState::Open ||
+             _keyTurnerState.lockState == NukiOpener::LockState::Opening) &&
+            _lastKeyTurnerState.lockState != NukiOpener::LockState::Open &&
+            _lastKeyTurnerState.lockState != NukiOpener::LockState::Opening)
+    {
+        Log->println("Nuki opener: Ring detected (CM)");
+        _network->publishRing(false);
+    }
+    else if((!isPinValid() || !_publishAuthData) &&
+            _statusUpdated &&
+            _keyTurnerState.trigger == NukiOpener::Trigger::Manual &&
+            (_keyTurnerState.lockState == NukiOpener::LockState::Open ||
+             _keyTurnerState.lockState == NukiOpener::LockState::Opening) &&
+            _lastKeyTurnerState.lockState == NukiOpener::LockState::RTOactive)
+    {
+        Log->println("Nuki opener: Ring detected (RTO)");
+        _network->publishRing(false);
+    }
+    else if((!isPinValid() || !_publishAuthData) &&
+            _statusUpdated &&
             _keyTurnerState.lockState == NukiOpener::LockState::Locked &&
             _lastKeyTurnerState.lockState == NukiOpener::LockState::Locked &&
-            _lastKeyTurnerState.nukiState == _keyTurnerState.nukiState &&
-            _keyTurnerState.nukiState != NukiOpener::State::ContinuousMode)
+            _lastKeyTurnerState.nukiState == _keyTurnerState.nukiState)
     {
-        Log->println("Nuki opener: Ring detected (Locked)");
+        Log->println("Nuki opener: Ring detected");
         _network->publishRing(true);
     }
     else
     {
-        if((!isPinValid() || !_publishAuthData) &&
-                _keyTurnerState.lockState != _lastKeyTurnerState.lockState &&
-                _keyTurnerState.lockState == NukiOpener::LockState::Open &&
-                _keyTurnerState.trigger == NukiOpener::Trigger::Manual)
-        {
-            Log->println("Nuki opener: Ring detected (Open)");
-            _network->publishRing(false);
-        }
-
         if(_publishAuthData)
         {
             Log->println("Publishing auth data");


### PR DESCRIPTION
## Description

**Nuki Opener rings are not reliably received in Home Assistant:** fixes #751
**Ring detected after reboot of Nuki Hub**: possibly fixes #744

## Checklist
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

## Details

This PR modifies the ring behavior to make it more consistent and reliable. TBH I probably still dont fully understand the meaning of every individual keyturner or lock state value and it felt more like figuring out the right combination of variables for each situation. However, this fix has been working reliably for me so far. Specifically:
* No rings are received when RTO/CM is activated
* No rings are received when the electric strike is actuated
* Rings are received immediately when the doorbell button is pressed, regardless of the configured mode