### PR TITLE
preventing immediate opener state update after success

### DIFF
--- a/src/NukiOpenerWrapper.cpp
+++ b/src/NukiOpenerWrapper.cpp
@@ -316,13 +316,8 @@ void NukiOpenerWrapper::update()
             _nextLockAction = (NukiOpener::LockAction) 0xff;
             _network->publishRetry("--");
             retryCount = 0;
-            _statusUpdated = true;
             Log->println("Opener: updating status after action");
             _statusUpdatedTs = ts;
-            if(_intervalLockstate > 10)
-            {
-                _nextLockStateUpdateTs = ts + 10 * 1000;
-            }
         }
         else
         {


### PR DESCRIPTION
## Description

**Timing issues leading to wrong Nuki states**: fixes #749

## Checklist
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

## Details

This PR prevents the Nuki Hub from immediately querying the Nuki Opener state right after receiving a success command due to timing issues which can lead to wrong states.