### PR TITLE
Fix buffer overflow in device ID string causing crash on HA discovery

### DIFF
--- a/src/HomeAssistantDiscovery.cpp
+++ b/src/HomeAssistantDiscovery.cpp
@@ -41,7 +41,7 @@ void HomeAssistantDiscovery::setupHASS(int type, uint32_t nukiId, char* nukiName
         }
     }
     #else
-    uint8_t mac[8];
+    uint8_t mac[8] = {0};
     esp_efuse_mac_get_default(mac);
     memcpy(&curDevId, &mac, 8);
     #endif

--- a/src/HomeAssistantDiscovery.h
+++ b/src/HomeAssistantDiscovery.h
@@ -63,7 +63,7 @@ private:
     String _hostname;
 
     JsonDocument _uidToName;
-    char _nukiHubUidString[20];
+    char _nukiHubUidString[21];
 
     char* _buffer;
     const size_t _bufferSize;

--- a/src/NukiNetwork.cpp
+++ b/src/NukiNetwork.cpp
@@ -197,8 +197,8 @@ void NukiNetwork::initialize()
 
     if(_hostname == "")
     {
-        char _nukiHubUidString[20];
-        uint8_t mac[8];
+        char _nukiHubUidString[21];
+        uint8_t mac[8] = {0};
         esp_efuse_mac_get_default(mac);
         uint64_t curDevId;
         memcpy(&curDevId, &mac, 8);
@@ -240,8 +240,8 @@ void NukiNetwork::initialize()
 
         if(_hostname == "")
         {
-            char _nukiHubUidString[20];
-            uint8_t mac[8];
+            char _nukiHubUidString[21];
+            uint8_t mac[8] = {0};
             esp_efuse_mac_get_default(mac);
             uint64_t curDevId;
             memcpy(&curDevId, &mac, 8);


### PR DESCRIPTION
Fix:
- Zero-initialize `mac[8]` so the ID is derived only from the real MAC bytes.
- Enlarge `_nukiHubUidString` from 20 to 21 bytes to hold a full uint64_t.

## Description:

**Related issue (if applicable):** fixes #765

## Checklist:
  - [x] The pull request is done against the latest master branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works
  - [x] I accept the [CLA](https://github.com/technyon/nuki_hub/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
